### PR TITLE
Feat: [사용자 관리] 사용자 등록 API 구현 (Moyeo-29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
+# Gradle
+.gradle/
+build/
+
+# IntelliJ IDEA
+.idea/
+*.iml
+out/
+
+# 환경 설정
+application.yml
+
 # Compiled class file
 *.class
 

--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,23 @@ repositories {
 }
 
 dependencies {
+	// Swagger
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
+
+	// DB
+	runtimeOnly 'org.postgresql:postgresql'
+
+	// Spring 기본
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// Lombok
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/moyeo/backend/auth/domain/Oauth.java
+++ b/src/main/java/com/moyeo/backend/auth/domain/Oauth.java
@@ -1,0 +1,27 @@
+package com.moyeo.backend.auth.domain;
+
+import com.moyeo.backend.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_oauth")
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Oauth {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @OneToOne
+    private User user;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    @Column(nullable = false, unique = true)
+    private String oauthId;
+}

--- a/src/main/java/com/moyeo/backend/auth/domain/OauthRepository.java
+++ b/src/main/java/com/moyeo/backend/auth/domain/OauthRepository.java
@@ -1,4 +1,5 @@
 package com.moyeo.backend.auth.domain;
 
 public interface OauthRepository {
+    Oauth save(Oauth oauth);
 }

--- a/src/main/java/com/moyeo/backend/auth/domain/OauthRepository.java
+++ b/src/main/java/com/moyeo/backend/auth/domain/OauthRepository.java
@@ -1,0 +1,4 @@
+package com.moyeo.backend.auth.domain;
+
+public interface OauthRepository {
+}

--- a/src/main/java/com/moyeo/backend/auth/domain/Provider.java
+++ b/src/main/java/com/moyeo/backend/auth/domain/Provider.java
@@ -1,0 +1,11 @@
+package com.moyeo.backend.auth.domain;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum Provider {
+    KAKAO("카카오"),
+    GOOGLE("구글");
+
+    private final String description;
+}

--- a/src/main/java/com/moyeo/backend/auth/infrastructure/JpaOauthRepository.java
+++ b/src/main/java/com/moyeo/backend/auth/infrastructure/JpaOauthRepository.java
@@ -1,0 +1,12 @@
+package com.moyeo.backend.auth.infrastructure;
+
+import com.moyeo.backend.auth.domain.Oauth;
+import com.moyeo.backend.auth.domain.OauthRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface JpaOauthRepository extends OauthRepository, JpaRepository<Oauth, UUID> {
+}

--- a/src/main/java/com/moyeo/backend/common/config/SwaggerConfig.java
+++ b/src/main/java/com/moyeo/backend/common/config/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package com.moyeo.backend.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Moyeo-Moyeo-Service")
+                        .description("모여모여 서비스 API")
+                        .version("v1"))
+                .components(new Components().addSecuritySchemes("bearerAuth",
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization")));
+    }
+}
+
+

--- a/src/main/java/com/moyeo/backend/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/moyeo/backend/common/config/WebSecurityConfig.java
@@ -1,0 +1,38 @@
+package com.moyeo.backend.common.config;
+
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.http.SessionCreationPolicy;
+
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .requestMatchers(
+                                "/users/register",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/v3/api-docs",
+                                "/v3/api-docs/**",
+                                "/api-docs",
+                                "/api-docs/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/moyeo/backend/common/enums/ErrorCode.java
+++ b/src/main/java/com/moyeo/backend/common/enums/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.moyeo.backend.common.enums;
+
+import com.moyeo.backend.common.response.ResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode implements ResponseCode {
+
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/moyeo/backend/common/enums/ErrorCode.java
+++ b/src/main/java/com/moyeo/backend/common/enums/ErrorCode.java
@@ -9,7 +9,9 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode implements ResponseCode {
 
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/moyeo/backend/common/exception/CustomException.java
+++ b/src/main/java/com/moyeo/backend/common/exception/CustomException.java
@@ -1,0 +1,11 @@
+package com.moyeo.backend.common.exception;
+
+import com.moyeo.backend.common.response.ResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+    private final ResponseCode responseCode;
+}

--- a/src/main/java/com/moyeo/backend/common/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/moyeo/backend/common/exception/CustomExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.moyeo.backend.common.exception;
+
+import com.moyeo.backend.common.response.ApiResponse;
+import com.moyeo.backend.common.response.ResponseCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j(topic = "CustomExceptionHandler")
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<Object>> handleCustomPaymentException(CustomException ex) {
+        ResponseCode responseCode = ex.getResponseCode();
+        return ResponseEntity
+                .status(responseCode.getStatus())
+                .body(ApiResponse.fail(responseCode));
+    }
+}

--- a/src/main/java/com/moyeo/backend/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/moyeo/backend/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,21 @@
+package com.moyeo.backend.common.exception;
+
+import com.moyeo.backend.common.enums.ErrorCode;
+import com.moyeo.backend.common.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j(topic = "GlobalExceptionHandler")
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiResponse<Object>> handleGenericException(Exception ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.fail(ErrorCode.BAD_REQUEST));
+    }
+}

--- a/src/main/java/com/moyeo/backend/common/response/ApiResponse.java
+++ b/src/main/java/com/moyeo/backend/common/response/ApiResponse.java
@@ -1,0 +1,19 @@
+package com.moyeo.backend.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T> (
+        String status,
+        int code,
+        String message,
+        T data
+) {
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>("success", 200, "API 요청이 성공했습니다.", data);
+    }
+
+    public static ApiResponse<Object> fail(ResponseCode responseCode) {
+        return new ApiResponse<>("fail", responseCode.getStatus().value(), responseCode.getMessage(), null);
+    }
+}

--- a/src/main/java/com/moyeo/backend/common/response/ApiResponse.java
+++ b/src/main/java/com/moyeo/backend/common/response/ApiResponse.java
@@ -1,7 +1,9 @@
 package com.moyeo.backend.common.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "공통 RESPONSE DTO ")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ApiResponse<T> (
         String status,

--- a/src/main/java/com/moyeo/backend/common/response/ResponseCode.java
+++ b/src/main/java/com/moyeo/backend/common/response/ResponseCode.java
@@ -1,0 +1,8 @@
+package com.moyeo.backend.common.response;
+
+import org.springframework.http.HttpStatus;
+
+public interface ResponseCode {
+    HttpStatus getStatus();
+    String getMessage();
+}

--- a/src/main/java/com/moyeo/backend/user/application/UserService.java
+++ b/src/main/java/com/moyeo/backend/user/application/UserService.java
@@ -1,0 +1,8 @@
+package com.moyeo.backend.user.application;
+
+import com.moyeo.backend.user.presentaion.dtos.RegisterRequestDto;
+import com.moyeo.backend.user.presentaion.dtos.UserResponseDto;
+
+public interface UserService {
+    UserResponseDto register(RegisterRequestDto requestDto);
+}

--- a/src/main/java/com/moyeo/backend/user/application/UserServiceImpl.java
+++ b/src/main/java/com/moyeo/backend/user/application/UserServiceImpl.java
@@ -1,0 +1,51 @@
+package com.moyeo.backend.user.application;
+
+import com.moyeo.backend.auth.domain.Oauth;
+import com.moyeo.backend.auth.domain.OauthRepository;
+import com.moyeo.backend.common.enums.ErrorCode;
+import com.moyeo.backend.common.exception.CustomException;
+import com.moyeo.backend.user.domain.User;
+import com.moyeo.backend.user.domain.UserRepository;
+import com.moyeo.backend.user.presentaion.dtos.RegisterRequestDto;
+import com.moyeo.backend.user.presentaion.dtos.UserResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final OauthRepository oauthRepository;
+
+    @Override
+    public UserResponseDto register(RegisterRequestDto requestDto) {
+        String nickname = requestDto.getNickname();
+        validNickname(nickname);
+
+        User user = User.builder()
+                .nickname(nickname)
+                .character(requestDto.getCharacter())
+                .build();
+
+        Oauth oauth = Oauth.builder()
+                .oauthId(requestDto.getOauthId())
+                .user(user)
+                .provider(requestDto.getProvider())
+                .build();
+
+        userRepository.save(user);
+        oauthRepository.save(oauth);
+        return UserResponseDto.builder().userId(user.getId()).build();
+    }
+
+    private void validNickname(String nickname) {
+        Optional<User> user = userRepository.findByNickname(nickname);
+
+        if (user.isPresent()) {
+            throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+    }
+}

--- a/src/main/java/com/moyeo/backend/user/domain/Character.java
+++ b/src/main/java/com/moyeo/backend/user/domain/Character.java
@@ -1,0 +1,8 @@
+package com.moyeo.backend.user.domain;
+
+public enum Character {
+    BEAR,
+    RABBIT,
+    CAT,
+    PIG
+}

--- a/src/main/java/com/moyeo/backend/user/domain/User.java
+++ b/src/main/java/com/moyeo/backend/user/domain/User.java
@@ -1,0 +1,23 @@
+package com.moyeo.backend.user.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "users")
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @Column(nullable = false, unique = true)
+    private String nickname;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Character character;
+}

--- a/src/main/java/com/moyeo/backend/user/domain/UserRepository.java
+++ b/src/main/java/com/moyeo/backend/user/domain/UserRepository.java
@@ -1,4 +1,9 @@
 package com.moyeo.backend.user.domain;
 
+import java.util.Optional;
+
 public interface UserRepository {
+    Optional<User> findByNickname(String nickname);
+
+    User save(User user);
 }

--- a/src/main/java/com/moyeo/backend/user/domain/UserRepository.java
+++ b/src/main/java/com/moyeo/backend/user/domain/UserRepository.java
@@ -1,0 +1,4 @@
+package com.moyeo.backend.user.domain;
+
+public interface UserRepository {
+}

--- a/src/main/java/com/moyeo/backend/user/infrastructure/JpaUserRepository.java
+++ b/src/main/java/com/moyeo/backend/user/infrastructure/JpaUserRepository.java
@@ -1,0 +1,13 @@
+package com.moyeo.backend.user.infrastructure;
+
+import com.moyeo.backend.user.domain.User;
+import com.moyeo.backend.user.domain.UserRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface JpaUserRepository extends UserRepository, JpaRepository<User, UUID> {
+
+}

--- a/src/main/java/com/moyeo/backend/user/presentaion/UserController.java
+++ b/src/main/java/com/moyeo/backend/user/presentaion/UserController.java
@@ -1,0 +1,29 @@
+package com.moyeo.backend.user.presentaion;
+
+import com.moyeo.backend.common.response.ApiResponse;
+import com.moyeo.backend.user.application.UserService;
+import com.moyeo.backend.user.presentaion.dtos.RegisterRequestDto;
+import com.moyeo.backend.user.presentaion.dtos.UserResponseDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j(topic = "UserController")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/users")
+public class UserController implements UserControllerDocs{
+
+    private final UserService userService;
+
+    @PostMapping("/register")
+    public ResponseEntity<ApiResponse<UserResponseDto>> register(@Valid @RequestBody RegisterRequestDto requestDto) {
+        log.info("oauthId : {}", requestDto.getOauthId());
+        return ResponseEntity.ok().body(ApiResponse.success(userService.register(requestDto)));
+    }
+}

--- a/src/main/java/com/moyeo/backend/user/presentaion/UserControllerDocs.java
+++ b/src/main/java/com/moyeo/backend/user/presentaion/UserControllerDocs.java
@@ -1,0 +1,15 @@
+package com.moyeo.backend.user.presentaion;
+
+import com.moyeo.backend.common.response.ApiResponse;
+import com.moyeo.backend.user.presentaion.dtos.RegisterRequestDto;
+import com.moyeo.backend.user.presentaion.dtos.UserResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "사용자 관리 API Controller", description = "사용자 관리 API 목록입니다.")
+public interface UserControllerDocs {
+
+    @Operation(summary = "사용자 등록 API", description = "사용자 등록 API 입니다.")
+    ResponseEntity<ApiResponse<UserResponseDto>> register(RegisterRequestDto requestDto);
+}

--- a/src/main/java/com/moyeo/backend/user/presentaion/dtos/RegisterRequestDto.java
+++ b/src/main/java/com/moyeo/backend/user/presentaion/dtos/RegisterRequestDto.java
@@ -5,10 +5,12 @@ import com.moyeo.backend.user.domain.Character;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Schema(description = "사용자 등록 REQUEST DTO")
+@Builder
 public class RegisterRequestDto {
     @NotNull
     private Provider provider;

--- a/src/main/java/com/moyeo/backend/user/presentaion/dtos/RegisterRequestDto.java
+++ b/src/main/java/com/moyeo/backend/user/presentaion/dtos/RegisterRequestDto.java
@@ -1,0 +1,24 @@
+package com.moyeo.backend.user.presentaion.dtos;
+
+import com.moyeo.backend.auth.domain.Provider;
+import com.moyeo.backend.user.domain.Character;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "사용자 등록 REQUEST DTO")
+public class RegisterRequestDto {
+    @NotNull
+    private Provider provider;
+
+    @NotBlank
+    private String oauthId;
+
+    @NotBlank
+    private String nickname;
+
+    @NotNull
+    private Character character;
+}

--- a/src/main/java/com/moyeo/backend/user/presentaion/dtos/UserResponseDto.java
+++ b/src/main/java/com/moyeo/backend/user/presentaion/dtos/UserResponseDto.java
@@ -1,0 +1,12 @@
+package com.moyeo.backend.user.presentaion.dtos;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "사용자 RESPONSE DTO")
+public class UserResponseDto {
+    private String userId;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=backend

--- a/src/test/java/com/moyeo/backend/user/application/UserServiceImplTest.java
+++ b/src/test/java/com/moyeo/backend/user/application/UserServiceImplTest.java
@@ -1,0 +1,78 @@
+package com.moyeo.backend.user.application;
+
+import com.moyeo.backend.auth.domain.Oauth;
+import com.moyeo.backend.auth.domain.OauthRepository;
+import com.moyeo.backend.auth.domain.Provider;
+import com.moyeo.backend.common.enums.ErrorCode;
+import com.moyeo.backend.common.exception.CustomException;
+import com.moyeo.backend.user.domain.Character;
+import com.moyeo.backend.user.domain.User;
+import com.moyeo.backend.user.domain.UserRepository;
+import com.moyeo.backend.user.presentaion.dtos.RegisterRequestDto;
+import com.moyeo.backend.user.presentaion.dtos.UserResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private OauthRepository oauthRepository;
+
+    @Test
+    @DisplayName("사용자 등록 API 성공 테스트")
+    void register_성공_테스트() {
+        // given
+        RegisterRequestDto requestDto = RegisterRequestDto.builder()
+                .provider(Provider.KAKAO)
+                .oauthId("1234567890")
+                .nickname("코딩짱짱맨")
+                .character(Character.BEAR)
+                .build();
+        when(userRepository.findByNickname("코딩짱짱맨")).thenReturn(Optional.empty());
+
+        // when
+        UserResponseDto responseDto = userService.register(requestDto);
+
+        // then
+        verify(userRepository).save(any(User.class));
+        verify(oauthRepository).save(any(Oauth.class));
+        assertNotNull(responseDto);
+    }
+
+    @Test
+    @DisplayName("사용자 등록 API 실패 테스트 - 닉네임 중복")
+    void register_닉네임_중복() {
+        // given: 테스트 데이터
+        RegisterRequestDto requestDto = RegisterRequestDto.builder()
+                .provider(Provider.KAKAO)
+                .oauthId("1234567890")
+                .nickname("코딩짱짱맨")
+                .character(Character.BEAR)
+                .build();
+        when(userRepository.findByNickname("코딩짱짱맨")).thenReturn(Optional.of(User.builder().nickname("코딩짱짱맨").build()));
+
+        // when & then
+        CustomException ex = assertThrows(CustomException.class, () -> {
+            userService.register(requestDto);
+        });
+        assertEquals(ErrorCode.NICKNAME_ALREADY_EXISTS, ex.getResponseCode());
+    }
+}


### PR DESCRIPTION
📌 Summary
<!-- 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- Jira 이슈 키를 포함하면 자동 연동됩니다 -->

- Related Jira Issue: [MOYEO-29]
- 사용자 등록 API 구현

✅ Key Changes
<!-- 주요 변경 사항 bullet 형식으로 작성 -->
- Security 적용
- Exception, Handler, 공통 응답 생성
- Swagger 적용
- Validate 적용
- 성공 처리 시 user, oauth 테이블 함께 저장
- 닉네임 중복 예외 처리

🧪 Testing
<!-- 어떻게 테스트했는지 설명 -->
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 테스트 코드 작성 (성공, 실패 - 닉네임 중복)
![Image](https://github.com/user-attachments/assets/4d30ea9a-a5e8-4867-aa14-962623dcf7bb)
- 포스트맨 응답 확인
(실패 - 닉네임 중복) <img width="717" alt="Image" src="https://github.com/user-attachments/assets/9c54fff6-e10e-4a2f-aff5-330bb0754d45" />
(성공) <img width="716" alt="Image" src="https://github.com/user-attachments/assets/05d28544-b8d7-450b-9100-36a01a63d348" />
(성공 - DB 확인)<img width="644" alt="Image" src="https://github.com/user-attachments/assets/cfce299d-7960-4bf0-bbbe-7674a4debd9b" />

🙋 To Reviewers
<!-- 리뷰어에게 알리고 싶은 내용 -->


[MOYEO-29]: https://jelliclesu.atlassian.net/browse/MOYEO-29?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ