### PR TITLE
Feat: [사용자 관리] 사용자 등록 API 추가 구현 (MOYEO-29)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# env
+.env
+
 # Gradle
 .gradle/
 build/

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,11 @@ repositories {
 }
 
 dependencies {
+	// Monitoring
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'com.github.loki4j:loki-logback-appender:1.5.1'
+
 	// MapStruct
 	implementation 'org.mapstruct:mapstruct:1.6.0'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.0'

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,11 @@ repositories {
 }
 
 dependencies {
+	// MapStruct
+	implementation 'org.mapstruct:mapstruct:1.6.0'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.0'
+	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+
 	//JWT
 	compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,70 @@
+services:
+  db:
+    image: postgres:15
+    container_name: moyeo-db
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "${DB_PORT}:5432"
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U ${DB_USER}" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: moyeo-prometheus
+    ports:
+      - "${PROMETHEUS_PORT}:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: moyeo-grafana
+    ports:
+      - "${GRAFANA_PORT}:3000"
+    depends_on:
+      - prometheus
+    volumes:
+      - grafana-data:/var/lib/grafana
+
+  loki:
+    image: grafana/loki:latest
+    container_name: moyeo-loki
+    ports:
+      - "${LOKI_PORT}:3100"
+    command: -config.file=/mnt/config/loki-config.yml
+    volumes:
+      - ./loki-config.yml:/mnt/config/loki-config.yml
+
+  backend:
+    build: .
+    container_name: moyeo-backend
+    ports:
+      - "${SERVER_PORT}:${SERVER_PORT}"
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      - SPRING_PROFILES_ACTIVE=local
+      - DB_HOST=db
+      - DB_PORT=${DB_PORT}
+      - DB_NAME=${DB_NAME}
+      - DB_USER=${DB_USER}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - SERVER_PORT=${SERVER_PORT}
+      - JWT_SECRET=${JWT_SECRET}
+      - KAKAO_CLIENT_ID=${KAKAO_CLIENT_ID}
+      - KAKAO_REDIRECT_URI=${KAKAO_REDIRECT_URI}
+      - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
+      - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET}
+      - GOOGLE_REDIRECT_URI=${GOOGLE_REDIRECT_URI}
+      - LOKI_PUSH_URL=${LOKI_PUSH_URL}
+volumes:
+  grafana-data:
+  prometheus-data:

--- a/loki-config.yml
+++ b/loki-config.yml
@@ -1,0 +1,50 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: moyeo-loki
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/analytics/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+#analytics:
+#  reporting_enabled: false

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,17 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'moyeo-prometheus'
+    static_configs:
+      - targets: ['moyeo-prometheus:9090']
+
+  - job_name: 'moyeo-grafana'
+    static_configs:
+      - targets: ['moyeo-grafana:3000']
+
+  - job_name: 'moyeo-app'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ["host.docker.internal:8080"]

--- a/src/main/java/com/moyeo/backend/auth/application/AuthServiceImpl.java
+++ b/src/main/java/com/moyeo/backend/auth/application/AuthServiceImpl.java
@@ -50,7 +50,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     private LoginResponseDto isNewUser(String oauthId, Provider provider) {
-        Optional<Oauth> oauth = oauthRepository.findByOauthIdAndProvider(oauthId, provider);
+        Optional<Oauth> oauth = oauthRepository.findByOauthIdAndProviderAndIsDeletedFalse(oauthId, provider);
 
         if (!oauth.isPresent()) {
             return LoginResponseDto.builder()

--- a/src/main/java/com/moyeo/backend/auth/application/mapper/OauthMapper.java
+++ b/src/main/java/com/moyeo/backend/auth/application/mapper/OauthMapper.java
@@ -1,0 +1,18 @@
+package com.moyeo.backend.auth.application.mapper;
+
+import com.moyeo.backend.auth.domain.Oauth;
+import com.moyeo.backend.user.application.dto.RegisterRequestDto;
+import com.moyeo.backend.user.domain.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+@Mapper(
+        componentModel = "spring",
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE
+)
+public interface OauthMapper {
+
+    @Mapping(target = "user" , expression = "java(user)")
+    Oauth toOauth(RegisterRequestDto requestDto, User user);
+}

--- a/src/main/java/com/moyeo/backend/auth/domain/Oauth.java
+++ b/src/main/java/com/moyeo/backend/auth/domain/Oauth.java
@@ -1,5 +1,6 @@
 package com.moyeo.backend.auth.domain;
 
+import com.moyeo.backend.common.domain.BaseEntity;
 import com.moyeo.backend.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -10,7 +11,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Oauth {
+public class Oauth extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private String id;

--- a/src/main/java/com/moyeo/backend/auth/domain/OauthRepository.java
+++ b/src/main/java/com/moyeo/backend/auth/domain/OauthRepository.java
@@ -5,5 +5,5 @@ import java.util.Optional;
 public interface OauthRepository {
     Oauth save(Oauth oauth);
 
-    Optional<Oauth> findByOauthIdAndProvider(String oauthId, Provider provider);
+    Optional<Oauth> findByOauthIdAndProviderAndIsDeletedFalse(String oauthId, Provider provider);
 }

--- a/src/main/java/com/moyeo/backend/common/config/WebSecurityConfig.java
+++ b/src/main/java/com/moyeo/backend/common/config/WebSecurityConfig.java
@@ -29,7 +29,8 @@ public class WebSecurityConfig {
                                 "/v3/api-docs",
                                 "/v3/api-docs/**",
                                 "/api-docs",
-                                "/api-docs/**"
+                                "/api-docs/**",
+                                "/actuator/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 );

--- a/src/main/java/com/moyeo/backend/common/domain/BaseEntity.java
+++ b/src/main/java/com/moyeo/backend/common/domain/BaseEntity.java
@@ -1,0 +1,45 @@
+package com.moyeo.backend.common.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.*;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedBy
+    @Column(updatable = false)
+    private String createdBy;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedBy
+    private String updatedBy;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    private String deletedBy;
+
+    private LocalDateTime deletedAt;
+
+    private Boolean isDeleted = false;
+
+    public void delete(String userId) {
+        this.deletedAt = LocalDateTime.now();
+        this.deletedBy = userId;
+        this.isDeleted = true;
+    }
+}

--- a/src/main/java/com/moyeo/backend/user/application/dto/RegisterRequestDto.java
+++ b/src/main/java/com/moyeo/backend/user/application/dto/RegisterRequestDto.java
@@ -1,6 +1,7 @@
 package com.moyeo.backend.user.application.dto;
 
 import com.moyeo.backend.auth.domain.Provider;
+import com.moyeo.backend.user.domain.Bank;
 import com.moyeo.backend.user.domain.Character;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
@@ -27,4 +28,12 @@ public class RegisterRequestDto {
     @Schema(description = "캐릭터 (BEAR, RABBIT, CAT, PIG)", example = "BEAR")
     @NotNull
     private Character character;
+
+    @Schema(description = "은행 (KB, SHINHAN, WOORI, NH, HANA, TOSS, KAKAO)", example = "KB")
+    @NotNull
+    private Bank bank;
+
+    @Schema(description = "계좌 번호", example = "812702-02-442698")
+    @NotNull
+    private String accountNumber;
 }

--- a/src/main/java/com/moyeo/backend/user/application/mapper/UserMapper.java
+++ b/src/main/java/com/moyeo/backend/user/application/mapper/UserMapper.java
@@ -1,0 +1,17 @@
+package com.moyeo.backend.user.application.mapper;
+
+import com.moyeo.backend.user.application.dto.RegisterRequestDto;
+import com.moyeo.backend.user.domain.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+@Mapper(
+        componentModel = "spring",
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE
+)
+public interface UserMapper {
+
+    @Mapping(target = "role", constant = "USER")
+    User toUser(RegisterRequestDto requestDto);
+}

--- a/src/main/java/com/moyeo/backend/user/application/service/UserServiceImpl.java
+++ b/src/main/java/com/moyeo/backend/user/application/service/UserServiceImpl.java
@@ -1,9 +1,11 @@
 package com.moyeo.backend.user.application.service;
 
+import com.moyeo.backend.auth.application.mapper.OauthMapper;
 import com.moyeo.backend.auth.domain.Oauth;
 import com.moyeo.backend.auth.domain.OauthRepository;
 import com.moyeo.backend.common.enums.ErrorCode;
 import com.moyeo.backend.common.exception.CustomException;
+import com.moyeo.backend.user.application.mapper.UserMapper;
 import com.moyeo.backend.user.domain.User;
 import com.moyeo.backend.user.domain.UserRepository;
 import com.moyeo.backend.user.application.dto.RegisterRequestDto;
@@ -19,22 +21,16 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final OauthRepository oauthRepository;
+    private final UserMapper userMapper;
+    private final OauthMapper oauthMapper;
 
     @Override
     public UserResponseDto register(RegisterRequestDto requestDto) {
         String nickname = requestDto.getNickname();
         validNickname(nickname);
 
-        User user = User.builder()
-                .nickname(nickname)
-                .character(requestDto.getCharacter())
-                .build();
-
-        Oauth oauth = Oauth.builder()
-                .oauthId(requestDto.getOauthId())
-                .user(user)
-                .provider(requestDto.getProvider())
-                .build();
+        User user = userMapper.toUser(requestDto);
+        Oauth oauth = oauthMapper.toOauth(requestDto, user);
 
         userRepository.save(user);
         oauthRepository.save(oauth);
@@ -42,7 +38,7 @@ public class UserServiceImpl implements UserService {
     }
 
     public void validNickname(String nickname) {
-        Optional<User> user = userRepository.findByNickname(nickname);
+        Optional<User> user = userRepository.findByNicknameAndIsDeletedFalse(nickname);
 
         if (user.isPresent()) {
             throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);

--- a/src/main/java/com/moyeo/backend/user/domain/Bank.java
+++ b/src/main/java/com/moyeo/backend/user/domain/Bank.java
@@ -1,0 +1,16 @@
+package com.moyeo.backend.user.domain;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum Bank {
+    KB("국민은행"),
+    SHINHAN("신한은행"),
+    WOORI("우리은행"),
+    NH("농협은행"),
+    HANA("하나은행"),
+    TOSS("토스뱅크"),
+    KAKAO("카카오뱅크");
+
+    private final String name;
+}

--- a/src/main/java/com/moyeo/backend/user/domain/User.java
+++ b/src/main/java/com/moyeo/backend/user/domain/User.java
@@ -1,5 +1,7 @@
 package com.moyeo.backend.user.domain;
 
+import com.moyeo.backend.auth.domain.Role;
+import com.moyeo.backend.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,7 +11,7 @@ import lombok.*;
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
     private String id;
@@ -20,4 +22,15 @@ public class User {
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Character character;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Bank bank;
+
+    @Column(nullable = false, unique = true)
+    private String accountNumber;
 }

--- a/src/main/java/com/moyeo/backend/user/domain/UserRepository.java
+++ b/src/main/java/com/moyeo/backend/user/domain/UserRepository.java
@@ -3,7 +3,7 @@ package com.moyeo.backend.user.domain;
 import java.util.Optional;
 
 public interface UserRepository {
-    Optional<User> findByNickname(String nickname);
+    Optional<User> findByNicknameAndIsDeletedFalse(String nickname);
 
     User save(User user);
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,5 +1,6 @@
 server:
   port: ${SERVER_PORT:8080}
+  address: 0.0.0.0
 
 spring:
   config:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,3 +42,12 @@ oauth:
       redirect_uri: ${GOOGLE_REDIRECT_URI}
       token-uri: https://oauth2.googleapis.com/token
       user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics, prometheus
+  endpoint:
+    health:
+      show-components: never

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,24 @@
+<configuration>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_PUSH_URL}</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=moyeo-app,level=%level</pattern>
+            </label>
+            <message class="com.github.loki4j.logback.JsonLayout" />
+        </format>
+    </appender>
+
+    <!--  DEBUG  -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="LOKI" />
+    </root>
+</configuration>

--- a/src/test/java/com/moyeo/backend/auth/application/AuthServiceImplTest.java
+++ b/src/test/java/com/moyeo/backend/auth/application/AuthServiceImplTest.java
@@ -101,7 +101,7 @@ class AuthServiceImplTest {
 
             OAuthUserInfo userInfo = mockUserInfo(oauthId);
             when(providerService.getUserInfo(accessToken)).thenReturn(userInfo);
-            when(oauthRepository.findByOauthIdAndProvider(oauthId, enumProvider))
+            when(oauthRepository.findByOauthIdAndProviderAndIsDeletedFalse(oauthId, enumProvider))
                     .thenReturn(Optional.empty());
 
             // when
@@ -128,7 +128,7 @@ class AuthServiceImplTest {
 
             OAuthUserInfo userInfo = mockUserInfo(oauthId);
             when(providerService.getUserInfo(accessToken)).thenReturn(userInfo);
-            when(oauthRepository.findByOauthIdAndProvider(oauthId, enumProvider))
+            when(oauthRepository.findByOauthIdAndProviderAndIsDeletedFalse(oauthId, enumProvider))
                     .thenReturn(Optional.of(oauth));
             when(jwtUtil.createToken(userId, nickname))
                     .thenReturn(jwtToken);
@@ -184,7 +184,7 @@ class AuthServiceImplTest {
             when(providerService.getAccessToken(code)).thenReturn(tokenResponse);
             when(providerService.getUserInfo(tokenResponse.getAccessToken())).thenReturn(userInfo);
 
-            when(oauthRepository.findByOauthIdAndProvider(oauthId, enumProvider))
+            when(oauthRepository.findByOauthIdAndProviderAndIsDeletedFalse(oauthId, enumProvider))
                     .thenReturn(Optional.empty());
 
             // when
@@ -219,7 +219,7 @@ class AuthServiceImplTest {
             OAuthUserInfo userInfo = mockUserInfo(oauthId);
             when(providerService.getAccessToken(code)).thenReturn(tokenResponse);
             when(providerService.getUserInfo(tokenResponse.getAccessToken())).thenReturn(userInfo);
-            when(oauthRepository.findByOauthIdAndProvider(oauthId, enumProvider))
+            when(oauthRepository.findByOauthIdAndProviderAndIsDeletedFalse(oauthId, enumProvider))
                     .thenReturn(Optional.of(oauth));
             when(jwtUtil.createToken(userId, nickname))
                     .thenReturn(jwtToken);

--- a/src/test/java/com/moyeo/backend/user/application/UserServiceImplTest.java
+++ b/src/test/java/com/moyeo/backend/user/application/UserServiceImplTest.java
@@ -1,21 +1,27 @@
 package com.moyeo.backend.user.application;
 
+import com.moyeo.backend.auth.application.mapper.OauthMapper;
+import com.moyeo.backend.auth.application.mapper.OauthMapperImpl;
 import com.moyeo.backend.auth.domain.Oauth;
 import com.moyeo.backend.auth.domain.OauthRepository;
 import com.moyeo.backend.auth.domain.Provider;
 import com.moyeo.backend.common.enums.ErrorCode;
 import com.moyeo.backend.common.exception.CustomException;
+import com.moyeo.backend.user.application.dto.RegisterRequestDto;
+import com.moyeo.backend.user.application.dto.UserResponseDto;
+import com.moyeo.backend.user.application.mapper.UserMapper;
+import com.moyeo.backend.user.application.mapper.UserMapperImpl;
 import com.moyeo.backend.user.application.service.UserServiceImpl;
+import com.moyeo.backend.user.domain.Bank;
 import com.moyeo.backend.user.domain.Character;
 import com.moyeo.backend.user.domain.User;
 import com.moyeo.backend.user.domain.UserRepository;
-import com.moyeo.backend.user.application.dto.RegisterRequestDto;
-import com.moyeo.backend.user.application.dto.UserResponseDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.Optional;
@@ -37,6 +43,12 @@ class UserServiceImplTest {
     @Mock
     private OauthRepository oauthRepository;
 
+    @Spy
+    private UserMapper userMapper = new UserMapperImpl();
+
+    @Spy
+    private OauthMapper oauthMapper = new OauthMapperImpl();
+
     @Test
     @DisplayName("사용자 등록 API 성공 테스트")
     void register_성공_테스트() {
@@ -46,8 +58,11 @@ class UserServiceImplTest {
                 .oauthId("1234567890")
                 .nickname("코딩짱짱맨")
                 .character(Character.BEAR)
+                .bank(Bank.KB)
+                .accountNumber("812702-02-442698")
                 .build();
-        when(userRepository.findByNickname("코딩짱짱맨")).thenReturn(Optional.empty());
+
+        when(userRepository.findByNicknameAndIsDeletedFalse("코딩짱짱맨")).thenReturn(Optional.empty());
 
         // when
         UserResponseDto responseDto = userService.register(requestDto);
@@ -68,7 +83,7 @@ class UserServiceImplTest {
                 .nickname("코딩짱짱맨")
                 .character(Character.BEAR)
                 .build();
-        when(userRepository.findByNickname("코딩짱짱맨")).thenReturn(Optional.of(User.builder().nickname("코딩짱짱맨").build()));
+        when(userRepository.findByNicknameAndIsDeletedFalse("코딩짱짱맨")).thenReturn(Optional.of(User.builder().nickname("코딩짱짱맨").build()));
 
         // when & then
         CustomException ex = assertThrows(CustomException.class, () -> {


### PR DESCRIPTION
📌 Summary
<!-- 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- Jira 이슈 키를 포함하면 자동 연동됩니다 -->

- Related Jira Issue: [Moyeo-29]
- 사용자 등록 API 추가 구현

✅ Key Changes
<!-- 주요 변경 사항 bullet 형식으로 작성 -->
- 은행, 계좌 필드 추가
- BaseEntity 도입
- Mapper 도입
- 테스트 코드 수정 (Mapper 적용)
- 모니터링 설정 추가 (Prometheus, Grafana, Loki)

🧪 Testing
<!-- 어떻게 테스트했는지 설명 -->
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 테스트 코드 리팩토링 <img width="350" alt="Image" src="https://github.com/user-attachments/assets/d06ce0d7-4126-4db9-91a5-2ff9af560336" />

- 포스트맨 응답 확인
([TC-01] 성공 - 사용자 등록 API)
  - 응답 <img width="697" alt="Image" src="https://github.com/user-attachments/assets/7d257a0a-db26-41cd-b5e2-290e704719ec" />
  - 실제 DB 확인 <img width="967" alt="Image" src="https://github.com/user-attachments/assets/f438b0da-c2dd-4a8e-bc08-9c87e9c796bb" />

- 모니터링 설정
  - Actuator 적용 확인 <img width="711" alt="Image" src="https://github.com/user-attachments/assets/b6966734-2c2f-436a-a134-74c52758256b" />
  - Prometheus 설정 확인 <img width="775" alt="Image" src="https://github.com/user-attachments/assets/7f94c9a9-2342-4bf0-9f0b-0c4497d3e1fb" />
  - Grafana 대시보드 <img width="1016" alt="Image" src="https://github.com/user-attachments/assets/745004f7-b979-4623-8aca-bf3c53df0a37" />
  - Grafana Loki 로그 설정 확인 <img width="778" alt="Image" src="https://github.com/user-attachments/assets/92d381d7-f290-4368-8e1d-385a772bcead" />
  - Grafana Slack 알림 설정 <img width="727" alt="Image" src="https://github.com/user-attachments/assets/a6a51846-78f4-420d-94a8-d1702e5f5ec1" />

🙋 To Reviewers
<!-- 리뷰어에게 알리고 싶은 내용 -->
- 사용자 등록 API 에 은행, 계좌 추가했는데, 게좌의 경우 계좌 인증 및 암호화까지 적용하면 너무 시간을 많이 잡아 먹을 것 같아서 추후 MVP 가 완료된 후 적용해보겠습니다!
- 감사로그를 위해 BaseEntity 도 추가했는데, JWT 설정이 필요한 부분은 인증/인가 브랜치에서 적용하도록 하겠습니다!
- 혹시 createdAt, createdBy 필드 조회 응답에 필요하시다면 말씀해주세요!
- 모니터링 설정도 해두었슴니다! 받아서 잘 동작하는 지 실행 해보셔도 좋을 것 같아요!