### PR TITLE
Feat: [챌린지 관리] 챌린지 참여 목록 조회 API 구현 (MOYEO-60)

### DIFF
--- a/src/main/java/com/moyeo/backend/challenge/basic/application/dto/ChallengeReadResponseDto.java
+++ b/src/main/java/com/moyeo/backend/challenge/basic/application/dto/ChallengeReadResponseDto.java
@@ -40,7 +40,7 @@ public class ChallengeReadResponseDto {
     @Schema(description = "챌린지 상세 설명", example = "매일 2시간 이상 공부하는 챌린지입니다.")
     private String description;
 
-    @Schema(description = "챌린지 상태", example = "매일 2시간 이상 공부하는 챌린지입니다.")
+    @Schema(description = "챌린지 상태", example = "RECRUITING")
     private ChallengeStatus status;
 
     @Schema(

--- a/src/main/java/com/moyeo/backend/challenge/basic/infrastructure/repository/CustomChallengeInfoRepositoryImpl.java
+++ b/src/main/java/com/moyeo/backend/challenge/basic/infrastructure/repository/CustomChallengeInfoRepositoryImpl.java
@@ -13,13 +13,11 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static com.moyeo.backend.challenge.basic.domain.QChallenge.challenge;
 import static com.moyeo.backend.common.util.QueryDslSortUtil.getOrderSpecifiers;

--- a/src/main/java/com/moyeo/backend/challenge/participation/application/dto/ChallengeParticipationReadRequestDto.java
+++ b/src/main/java/com/moyeo/backend/challenge/participation/application/dto/ChallengeParticipationReadRequestDto.java
@@ -1,0 +1,26 @@
+package com.moyeo.backend.challenge.participation.application.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.moyeo.backend.challenge.basic.domain.enums.ChallengeStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "챌린지 참여 목록 REQUEST PARAMETER DTO")
+public class ChallengeParticipationReadRequestDto {
+
+    @Schema(description = "날짜", example = "2025-08-14")
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    @Schema(description = "챌린지 상태", example = "INPROGRESS")
+    private ChallengeStatus status;
+}

--- a/src/main/java/com/moyeo/backend/challenge/participation/application/dto/ChallengeParticipationReadRequestDto.java
+++ b/src/main/java/com/moyeo/backend/challenge/participation/application/dto/ChallengeParticipationReadRequestDto.java
@@ -1,12 +1,12 @@
 package com.moyeo.backend.challenge.participation.application.dto;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.moyeo.backend.challenge.basic.domain.enums.ChallengeStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
@@ -18,7 +18,7 @@ import java.time.LocalDate;
 public class ChallengeParticipationReadRequestDto {
 
     @Schema(description = "날짜", example = "2025-08-14")
-    @JsonFormat(pattern = "yyyy-MM-dd")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
     private LocalDate date;
 
     @Schema(description = "챌린지 상태", example = "INPROGRESS")

--- a/src/main/java/com/moyeo/backend/challenge/participation/application/dto/ChallengeParticipationReadResponseDto.java
+++ b/src/main/java/com/moyeo/backend/challenge/participation/application/dto/ChallengeParticipationReadResponseDto.java
@@ -1,0 +1,19 @@
+package com.moyeo.backend.challenge.participation.application.dto;
+
+import com.moyeo.backend.challenge.basic.application.dto.ChallengeReadResponseDto;
+import com.moyeo.backend.challenge.participation.domain.enums.ParticipationStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@Schema(description = "챌린지 참여 READ RESPONSE DTO")
+public class ChallengeParticipationReadResponseDto {
+
+    @Schema(description = "챌린지 정보")
+    private ChallengeReadResponseDto challenge;
+
+    @Schema(description = "챌린지 참여 상태", example = "INPROGRESS")
+    private ParticipationStatus participationStatus;
+}

--- a/src/main/java/com/moyeo/backend/challenge/participation/application/mapper/ChallengeParticipationMapper.java
+++ b/src/main/java/com/moyeo/backend/challenge/participation/application/mapper/ChallengeParticipationMapper.java
@@ -1,6 +1,8 @@
 package com.moyeo.backend.challenge.participation.application.mapper;
 
+import com.moyeo.backend.challenge.basic.application.mapper.ChallengeMapper;
 import com.moyeo.backend.challenge.basic.domain.Challenge;
+import com.moyeo.backend.challenge.participation.application.dto.ChallengeParticipationReadResponseDto;
 import com.moyeo.backend.challenge.participation.domain.ChallengeParticipation;
 import com.moyeo.backend.user.domain.User;
 import org.mapstruct.Mapper;
@@ -9,7 +11,8 @@ import org.mapstruct.NullValuePropertyMappingStrategy;
 
 @Mapper(
         componentModel = "spring",
-        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE,
+        uses = { ChallengeMapper.class}
 )
 public interface ChallengeParticipationMapper {
 
@@ -18,4 +21,7 @@ public interface ChallengeParticipationMapper {
     @Mapping(target = "user", expression = "java(user)")
     @Mapping(target = "status", ignore = true)
     ChallengeParticipation toParticipant(Challenge challenge, User user);
+
+    @Mapping(target = "participationStatus", source = "status")
+    ChallengeParticipationReadResponseDto toParticipantDto(ChallengeParticipation challengeParticipation);
 }

--- a/src/main/java/com/moyeo/backend/challenge/participation/application/service/ChallengeParticipationService.java
+++ b/src/main/java/com/moyeo/backend/challenge/participation/application/service/ChallengeParticipationService.java
@@ -1,10 +1,16 @@
 package com.moyeo.backend.challenge.participation.application.service;
 
+import com.moyeo.backend.challenge.participation.application.dto.ChallengeParticipationReadRequestDto;
+import com.moyeo.backend.challenge.participation.application.dto.ChallengeParticipationReadResponseDto;
 import com.moyeo.backend.challenge.participation.application.dto.ChallengeParticipationRequestDto;
+import com.moyeo.backend.common.response.PageResponse;
+import org.springframework.data.domain.Pageable;
 
 public interface ChallengeParticipationService {
 
     Boolean check(String challengeId);
 
     void participate(String challengeId, ChallengeParticipationRequestDto requestDto);
+
+    PageResponse<ChallengeParticipationReadResponseDto> gets(ChallengeParticipationReadRequestDto requestDto, Pageable pageable);
 }

--- a/src/main/java/com/moyeo/backend/challenge/participation/infrastructure/repository/CustomChallengeParticipationRepository.java
+++ b/src/main/java/com/moyeo/backend/challenge/participation/infrastructure/repository/CustomChallengeParticipationRepository.java
@@ -1,16 +1,11 @@
-package com.moyeo.backend.challenge.participation.domain;
+package com.moyeo.backend.challenge.participation.infrastructure.repository;
 
 import com.moyeo.backend.challenge.participation.application.dto.ChallengeParticipationReadRequestDto;
 import com.moyeo.backend.challenge.participation.application.dto.ChallengeParticipationReadResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
-import java.util.Optional;
-
-public interface ChallengeParticipationRepository {
-    Optional<ChallengeParticipation> findByChallengeIdAndUserIdAndIsDeletedFalse(String challengeId, String userId);
-
-    ChallengeParticipation save(ChallengeParticipation participation);
+public interface CustomChallengeParticipationRepository {
 
     Page<ChallengeParticipationReadResponseDto> findMyParticipation(String userId, ChallengeParticipationReadRequestDto requestDto, Pageable pageable);
 }

--- a/src/main/java/com/moyeo/backend/challenge/participation/infrastructure/repository/CustomChallengeParticipationRepositoryImpl.java
+++ b/src/main/java/com/moyeo/backend/challenge/participation/infrastructure/repository/CustomChallengeParticipationRepositoryImpl.java
@@ -69,6 +69,7 @@ public class CustomChallengeParticipationRepositoryImpl implements CustomChallen
         return new BooleanBuilder()
                 .and(isMine(userId))
                 .and(isDeletedFalse())
+                .and(challengeIsDeletedFalse())
                 .and(eqStatus(requestDto.getStatus()))
                 .and(betweenDate(requestDto.getDate()));
     }
@@ -79,6 +80,10 @@ public class CustomChallengeParticipationRepositoryImpl implements CustomChallen
 
     private BooleanExpression isDeletedFalse() {
         return challengeParticipation.isDeleted.isFalse();
+    }
+
+    private BooleanExpression challengeIsDeletedFalse() {
+        return challenge.isDeleted.isFalse();
     }
 
     private BooleanExpression eqStatus(ChallengeStatus status) {

--- a/src/main/java/com/moyeo/backend/challenge/participation/infrastructure/repository/CustomChallengeParticipationRepositoryImpl.java
+++ b/src/main/java/com/moyeo/backend/challenge/participation/infrastructure/repository/CustomChallengeParticipationRepositoryImpl.java
@@ -1,0 +1,95 @@
+package com.moyeo.backend.challenge.participation.infrastructure.repository;
+
+import com.moyeo.backend.challenge.basic.domain.enums.ChallengeStatus;
+import com.moyeo.backend.challenge.participation.application.dto.ChallengeParticipationReadRequestDto;
+import com.moyeo.backend.challenge.participation.application.dto.ChallengeParticipationReadResponseDto;
+import com.moyeo.backend.challenge.participation.application.mapper.ChallengeParticipationMapper;
+import com.moyeo.backend.challenge.participation.domain.ChallengeParticipation;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static com.moyeo.backend.challenge.basic.domain.QChallenge.challenge;
+import static com.moyeo.backend.challenge.participation.domain.QChallengeParticipation.challengeParticipation;
+import static com.moyeo.backend.common.util.QueryDslSortUtil.getOrderSpecifiers;
+
+@RequiredArgsConstructor
+public class CustomChallengeParticipationRepositoryImpl implements CustomChallengeParticipationRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final ChallengeParticipationMapper participationMapper;
+
+    private static final Map<String, ComparableExpressionBase<?>> SORT_PARAMS = Map.of(
+            "createdAt", challengeParticipation.createdAt
+    );
+
+    @Override
+    public Page<ChallengeParticipationReadResponseDto> findMyParticipation(String userId, ChallengeParticipationReadRequestDto requestDto, Pageable pageable) {
+
+        BooleanBuilder booleanBuilder = booleanBuilder(userId, requestDto);
+
+        JPAQuery<ChallengeParticipation> participation = jpaQueryFactory
+                .selectFrom(challengeParticipation)
+                .join(challengeParticipation.challenge, challenge).fetchJoin()
+                .where(booleanBuilder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(getOrderSpecifiers(pageable, SORT_PARAMS));
+
+        JPAQuery<Long> total = jpaQueryFactory
+                .select(challengeParticipation.count())
+                .from(challengeParticipation)
+                .join(challengeParticipation.challenge, challenge)
+                .where(booleanBuilder);
+
+        List<ChallengeParticipationReadResponseDto> results = participation.fetch().stream()
+                .map(participationMapper::toParticipantDto)
+                .toList();
+
+        return PageableExecutionUtils.getPage(
+                results,
+                pageable,
+                total::fetchOne
+        );
+    }
+
+
+    private BooleanBuilder booleanBuilder(String userId, ChallengeParticipationReadRequestDto requestDto) {
+
+        return new BooleanBuilder()
+                .and(isMine(userId))
+                .and(isDeletedFalse())
+                .and(eqStatus(requestDto.getStatus()))
+                .and(betweenDate(requestDto.getDate()));
+    }
+
+    private BooleanExpression isMine(String userId) {
+        return challengeParticipation.user.id.eq(userId);
+    }
+
+    private BooleanExpression isDeletedFalse() {
+        return challengeParticipation.isDeleted.isFalse();
+    }
+
+    private BooleanExpression eqStatus(ChallengeStatus status) {
+        return status != null ? challenge.status.eq(status) : null;
+
+    }
+    private BooleanExpression betweenDate(LocalDate date) {
+        if (date == null) return null;
+        return challenge.startDate.loe(date)
+                .and(challenge.endDate.goe(date));
+    }
+
+
+}

--- a/src/main/java/com/moyeo/backend/challenge/participation/infrastructure/repository/JpaChallengeParticipationRepository.java
+++ b/src/main/java/com/moyeo/backend/challenge/participation/infrastructure/repository/JpaChallengeParticipationRepository.java
@@ -8,5 +8,5 @@ import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
-public interface JpaChallengeParticipationRepository extends ChallengeParticipationRepository, JpaRepository<ChallengeParticipation, UUID> {
+public interface JpaChallengeParticipationRepository extends ChallengeParticipationRepository, JpaRepository<ChallengeParticipation, UUID>, CustomChallengeParticipationRepository {
 }

--- a/src/main/java/com/moyeo/backend/challenge/participation/presentation/ChallengeParticipationController.java
+++ b/src/main/java/com/moyeo/backend/challenge/participation/presentation/ChallengeParticipationController.java
@@ -1,11 +1,16 @@
 package com.moyeo.backend.challenge.participation.presentation;
 
+import com.moyeo.backend.challenge.participation.application.dto.ChallengeParticipationReadRequestDto;
+import com.moyeo.backend.challenge.participation.application.dto.ChallengeParticipationReadResponseDto;
 import com.moyeo.backend.challenge.participation.application.dto.ChallengeParticipationRequestDto;
 import com.moyeo.backend.challenge.participation.application.service.ChallengeParticipationService;
+import com.moyeo.backend.common.request.PageRequestDto;
 import com.moyeo.backend.common.response.ApiResponse;
+import com.moyeo.backend.common.response.PageResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,5 +35,12 @@ public class ChallengeParticipationController implements ChallengeParticipationC
             @Valid @RequestBody ChallengeParticipationRequestDto requestDto) {
         challengeParticipationService.participate(challengeId, requestDto);
         return ResponseEntity.ok().body(ApiResponse.success());
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<PageResponse<ChallengeParticipationReadResponseDto>>> gets(
+            @ParameterObject @ModelAttribute ChallengeParticipationReadRequestDto requestDto,
+            @ParameterObject @ModelAttribute PageRequestDto page) {
+        return ResponseEntity.ok().body(ApiResponse.success(challengeParticipationService.gets(requestDto, page.toPageable())));
     }
 }

--- a/src/main/java/com/moyeo/backend/challenge/participation/presentation/ChallengeParticipationControllerDocs.java
+++ b/src/main/java/com/moyeo/backend/challenge/participation/presentation/ChallengeParticipationControllerDocs.java
@@ -1,8 +1,14 @@
 package com.moyeo.backend.challenge.participation.presentation;
 
 
+import com.moyeo.backend.challenge.basic.application.dto.ChallengeReadRequestDto;
+import com.moyeo.backend.challenge.basic.application.dto.ChallengeReadResponseDto;
+import com.moyeo.backend.challenge.participation.application.dto.ChallengeParticipationReadRequestDto;
+import com.moyeo.backend.challenge.participation.application.dto.ChallengeParticipationReadResponseDto;
 import com.moyeo.backend.challenge.participation.application.dto.ChallengeParticipationRequestDto;
+import com.moyeo.backend.common.request.PageRequestDto;
 import com.moyeo.backend.common.response.ApiResponse;
+import com.moyeo.backend.common.response.PageResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,4 +24,8 @@ public interface ChallengeParticipationControllerDocs {
 
     @Operation(summary = "챌린지 참여 API", description = "챌린지 참여 API 입니다.")
     ResponseEntity<ApiResponse<Void>> participate(String id, ChallengeParticipationRequestDto requestDto);
+
+    @Operation(summary = "챌린지 참여 목록 조회 API", description = "챌린지 목록 조회 API 입니다.")
+    ResponseEntity<ApiResponse<PageResponse<ChallengeParticipationReadResponseDto>>> gets(
+            ChallengeParticipationReadRequestDto requestDto, PageRequestDto page);
 }


### PR DESCRIPTION
📌 Summary
<!-- 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- Jira 이슈 키를 포함하면 자동 연동됩니다 -->

- Related Jira Issue: [MOYEO-60]
- 챌린지 참여 목록 조회 API 구현

✅ Key Changes
<!-- 주요 변경 사항 bullet 형식으로 작성 -->
- /me 엔드포인트로 본인 정보만 조회 가능하도록 구현
- QueryDSL 적용 (date, status 필터 가능)
- 응답에 중첩 DTO 사용 (challenge)

🧪 Testing
<!-- 어떻게 테스트했는지 설명 -->
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 포스트맨 응답 결과
<img width="994" height="896" alt="Image" src="https://github.com/user-attachments/assets/69972dd7-d92a-460a-b40d-62563c6a0fe1" />

🙋 To Reviewers
<!-- 리뷰어에게 알리고 싶은 내용 -->
- date 로 날짜 필터 가능합니다 -> 메인 페이지에서 날짜별 참여 조회시 활용하면 될 것 같아요
- status 필터도 일단 추가했습니다! -> 추후 진행 중인 목록, 끝난 목록 등 나타낼 때 활용될 수 있을 듯 합니다.
- date 유효성 검사 로직은 추후 추가 예쩡입니다.
@coderabbit 한글 탑변 부탁드립니다.

[MOYEO-60]: https://jelliclesu.atlassian.net/browse/MOYEO-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a paginated "My Participations" GET endpoint with filters for date and status; responses include challenge details and participation status.

* **Documentation**
  * Added request/response schemas and pagination docs for the new endpoint.
  * Updated API examples to show enum values for challenge status.

* **Style**
  * Removed unused imports to improve code cleanliness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->