### PR TITLE
Feat: [챌린지 관리] 본인 챌린지 인증 내용 단건 조회 API 구현 (MOYEO-69)

### DIFF
--- a/src/main/java/com/moyeo/backend/auth/application/dto/LoginResponseDto.java
+++ b/src/main/java/com/moyeo/backend/auth/application/dto/LoginResponseDto.java
@@ -1,5 +1,7 @@
 package com.moyeo.backend.auth.application.dto;
 
+import com.moyeo.backend.user.domain.Bank;
+import com.moyeo.backend.user.domain.Character;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,4 +18,19 @@ public class LoginResponseDto {
 
     @Schema(description = "소셜 로그인 고유 사용자 ID (신규 회원일 경우 응답)", example = "1122385832637846")
     private String oauthId;
+
+    @Schema(description = "사용자 ID", example = "d8f52fe-f9c0-41db-9e52-57f25185c382")
+    private String userId;
+
+    @Schema(description = "닉네임", example = "코딩짱짱맨")
+    private String nickname;
+
+    @Schema(description = "캐릭터 (BEAR, RABBIT, CAT, PIG)", example = "BEAR")
+    private Character character;
+
+    @Schema(description = "은행 (KB, SHINHAN, WOORI, NH, HANA, TOSS, KAKAO)", example = "KB")
+    private Bank bank;
+
+    @Schema(description = "계좌 번호", example = "812702-02-442698")
+    private String accountNumber;
 }

--- a/src/main/java/com/moyeo/backend/auth/application/service/AuthServiceImpl.java
+++ b/src/main/java/com/moyeo/backend/auth/application/service/AuthServiceImpl.java
@@ -65,6 +65,11 @@ public class AuthServiceImpl implements AuthService {
         return LoginResponseDto.builder()
                 .isNewUser(false)
                 .jwtAccessToken(jwtUtil.createToken(oauth.get().getUser().getId(), oauth.get().getUser().getNickname()))
+                .userId(oauth.get().getUser().getId())
+                .nickname(oauth.get().getUser().getNickname())
+                .character(oauth.get().getUser().getCharacter())
+                .bank(oauth.get().getUser().getBank())
+                .accountNumber(oauth.get().getUser().getAccountNumber())
                 .build();
     }
 }

--- a/src/main/java/com/moyeo/backend/challenge/log/application/service/ChallengeLogService.java
+++ b/src/main/java/com/moyeo/backend/challenge/log/application/service/ChallengeLogService.java
@@ -11,4 +11,6 @@ public interface ChallengeLogService {
     ChallengeLogResponseDto update(String challengeId, String logId, ChallengeLogContentRequestDto requestDto);
 
     PageResponse<ChallengeLogReadResponseDto> gets(String challengeId, ChallengeLogReadRequestDto requestDto, Pageable pageable);
+
+    ChallengeLogReadResponseDto getByUser(String challengeId);
 }

--- a/src/main/java/com/moyeo/backend/challenge/log/application/service/ChallengeLogServiceImpl.java
+++ b/src/main/java/com/moyeo/backend/challenge/log/application/service/ChallengeLogServiceImpl.java
@@ -80,4 +80,16 @@ public class ChallengeLogServiceImpl implements ChallengeLogService {
         Page<ChallengeLogReadResponseDto> logs = challengeLogRepository.getLogs(challengeId, requestDto, pageable);
         return pageMapper.toPageResponse(logs);
     }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ChallengeLogReadResponseDto getByUser(String challengeId) {
+        User currentUser = userContextService.getCurrentUser();
+        String userId = currentUser.getId();
+
+        Challenge challenge = challengeValidator.getValidChallengeById(challengeId);
+        ChallengeParticipation participation = participationValidator.getValidParticipationByUserId(challenge.getId(), userId);
+        ChallengeLog challengeLog = logValidator.getValidLogByUser(participation.getId());
+        return challengeLogMapper.toLogDto(challengeLog);
+    }
 }

--- a/src/main/java/com/moyeo/backend/challenge/log/application/validator/ChallengeLogValidator.java
+++ b/src/main/java/com/moyeo/backend/challenge/log/application/validator/ChallengeLogValidator.java
@@ -60,4 +60,10 @@ public class ChallengeLogValidator {
             throw new CustomException(ErrorCode.CHALLENGE_LOG_CONTENT_TYPE_MISMATCH);
         }
     }
+
+    public ChallengeLog getValidLogByUser(String participationId) {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        return logRepository.findByParticipationIdAndIsDeletedFalseAndDate(participationId, today)
+                .orElseThrow(() -> new CustomException(ErrorCode.CHALLENGE_LOG_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/moyeo/backend/challenge/log/domain/ChallengeLogRepository.java
+++ b/src/main/java/com/moyeo/backend/challenge/log/domain/ChallengeLogRepository.java
@@ -5,6 +5,7 @@ import com.moyeo.backend.challenge.log.application.dto.ChallengeLogReadResponseD
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 public interface ChallengeLogRepository {
@@ -14,4 +15,6 @@ public interface ChallengeLogRepository {
     Optional<ChallengeLog> findByIdAndIsDeletedFalse(String logId);
 
     Page<ChallengeLogReadResponseDto> getLogs(String challengeId, ChallengeLogReadRequestDto requestDto, Pageable pageable);
+
+    Optional<ChallengeLog> findByParticipationIdAndIsDeletedFalseAndDate(String participationId, LocalDate date);
 }

--- a/src/main/java/com/moyeo/backend/challenge/log/presentation/ChallengeLogController.java
+++ b/src/main/java/com/moyeo/backend/challenge/log/presentation/ChallengeLogController.java
@@ -47,4 +47,11 @@ public class ChallengeLogController implements  ChallengeLogControllerDocs{
         return ResponseEntity.ok().body(ApiResponse.success(
                 challengeLogService.gets(challengeId, requestDto, page.toPageable())));
     }
+
+    @GetMapping("/{challengeId}/logs/me")
+    public ResponseEntity<ApiResponse<ChallengeLogReadResponseDto>> getByUser(@PathVariable String challengeId) {
+        return ResponseEntity.ok().body(ApiResponse.success(
+                challengeLogService.getByUser(challengeId)
+        ));
+    }
 }

--- a/src/main/java/com/moyeo/backend/challenge/log/presentation/ChallengeLogControllerDocs.java
+++ b/src/main/java/com/moyeo/backend/challenge/log/presentation/ChallengeLogControllerDocs.java
@@ -25,4 +25,7 @@ public interface ChallengeLogControllerDocs {
     ResponseEntity<ApiResponse<PageResponse<ChallengeLogReadResponseDto>>> gets(String challengeId,
                                                                  ChallengeLogReadRequestDto requestDto,
                                                                  PageRequestDto page);
+
+    @Operation(summary = "본인 챌린지 인증 내용 단건 조회 API", description = "본인 챌린지 인증 내용 단건 조회 API 입니다.")
+    ResponseEntity<ApiResponse<ChallengeLogReadResponseDto>> getByUser(String challengeId);
 }


### PR DESCRIPTION
- 당일 날짜의 본인 챌린지 인증 내용 단건 조회

📌 Summary
<!-- 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- Jira 이슈 키를 포함하면 자동 연동됩니다 -->

- Related Jira Issue: [MOYEO-69]
- 본인 챌린지 인증 내용 단건 조회 API 구현

✅ Key Changes
<!-- 주요 변경 사항 bullet 형식으로 작성 -->
- 당일 날짜의 본인 챌린지 인증 내용 단건 조회

🧪 Testing
<!-- 어떻게 테스트했는지 설명 -->
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 포트스맨 응답 확인
<img width="1988" height="1748" alt="image" src="https://github.com/user-attachments/assets/e114719c-d9d0-4ba5-807c-21d3b70a3998" />

🙋 To Reviewers
<!-- 리뷰어에게 알리고 싶은 내용 -->
- 챌린지 당일 키워드, 인증 내용 조회 시 활용하면 될 것 같습니다!

@coderabbitai 한글 답변 부탁드립니다.


[MOYEO-69]: https://jelliclesu.atlassian.net/browse/MOYEO-69?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Added an endpoint to retrieve your own challenge log for a specific challenge: GET /v1/challenges/{challengeId}/logs/me — returns a single log entry for the authenticated user.
  * Login responses for existing users now include additional user metadata (userId, nickname, character, bank, accountNumber) alongside the access token.

* Documentation
  * API docs updated to include the new “My Challenge Log” endpoint and the expanded login response fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->