### PR TITLE
Feat: [사용자 관리] 일별 본인 공부 시간 목록 조회 API 구현 (MOYEO-73)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,9 @@ repositories {
 }
 
 dependencies {
+	// Spring Batch
+	implementation "org.springframework.boot:spring-boot-starter-batch"
+
 	//Kafka
 	implementation 'org.springframework.kafka:spring-kafka'
 	implementation 'com.fasterxml.jackson.core:jackson-databind'

--- a/src/main/java/com/moyeo/backend/BackendApplication.java
+++ b/src/main/java/com/moyeo/backend/BackendApplication.java
@@ -3,9 +3,11 @@ package com.moyeo.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing(auditorAwareRef = "auditorAwareImpl")
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/moyeo/backend/challenge/log/application/dto/ChallengeLogDailyAggregateDto.java
+++ b/src/main/java/com/moyeo/backend/challenge/log/application/dto/ChallengeLogDailyAggregateDto.java
@@ -1,0 +1,15 @@
+package com.moyeo.backend.challenge.log.application.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+import java.time.LocalDate;
+
+public record ChallengeLogDailyAggregateDto(
+        String userId,
+        LocalDate date,
+        int totalMinutes)
+{
+    @QueryProjection
+    public ChallengeLogDailyAggregateDto {
+    }
+}

--- a/src/main/java/com/moyeo/backend/challenge/log/domain/ChallengeLogRepository.java
+++ b/src/main/java/com/moyeo/backend/challenge/log/domain/ChallengeLogRepository.java
@@ -1,11 +1,13 @@
 package com.moyeo.backend.challenge.log.domain;
 
+import com.moyeo.backend.challenge.log.application.dto.ChallengeLogDailyAggregateDto;
 import com.moyeo.backend.challenge.log.application.dto.ChallengeLogReadRequestDto;
 import com.moyeo.backend.challenge.log.application.dto.ChallengeLogReadResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 public interface ChallengeLogRepository {
@@ -17,4 +19,6 @@ public interface ChallengeLogRepository {
     Page<ChallengeLogReadResponseDto> getLogs(String challengeId, ChallengeLogReadRequestDto requestDto, Pageable pageable);
 
     Optional<ChallengeLog> findByParticipationIdAndIsDeletedFalseAndDate(String participationId, LocalDate date);
+
+    List<ChallengeLogDailyAggregateDto> aggregateDailyByUser(LocalDate date);
 }

--- a/src/main/java/com/moyeo/backend/challenge/log/infrastructure/repository/CustomChallengeLogRepository.java
+++ b/src/main/java/com/moyeo/backend/challenge/log/infrastructure/repository/CustomChallengeLogRepository.java
@@ -1,11 +1,17 @@
 package com.moyeo.backend.challenge.log.infrastructure.repository;
 
+import com.moyeo.backend.challenge.log.application.dto.ChallengeLogDailyAggregateDto;
 import com.moyeo.backend.challenge.log.application.dto.ChallengeLogReadRequestDto;
 import com.moyeo.backend.challenge.log.application.dto.ChallengeLogReadResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface CustomChallengeLogRepository {
 
     Page<ChallengeLogReadResponseDto> getLogs(String challengeId, ChallengeLogReadRequestDto requestDto, Pageable pageable);
+
+    List<ChallengeLogDailyAggregateDto> aggregateDailyByUser(LocalDate date);
 }

--- a/src/main/java/com/moyeo/backend/challenge/log/infrastructure/repository/CustomChallengeLogRepositoryImpl.java
+++ b/src/main/java/com/moyeo/backend/challenge/log/infrastructure/repository/CustomChallengeLogRepositoryImpl.java
@@ -76,11 +76,13 @@ public class CustomChallengeLogRepositoryImpl implements CustomChallengeLogRepos
 
         BooleanBuilder booleanBuilder = booleanBuilder(date);
 
-        NumberExpression<Integer> totalMinutes = Expressions.numberTemplate(
+        NumberExpression<Integer> minutesPerLog = Expressions.numberTemplate(
                 Integer.class,
-                "COALESCE(SUM(FLOOR(EXTRACT(EPOCH FROM ({0} - {1})) / 60.0)::int), 0)::int",
+                "cast(floor( (cast(function('date_part','epoch', function('age', {0}, {1})) as big_decimal)) / 60.0 ) as integer)",
                 challengeLog.updatedAt, challengeLog.createdAt
         );
+
+        NumberExpression<Integer> totalMinutes = minutesPerLog.sum().coalesce(0);
 
         return jpaQueryFactory.select(new QChallengeLogDailyAggregateDto(
                 challengeParticipation.user.id,

--- a/src/main/java/com/moyeo/backend/challenge/log/infrastructure/repository/CustomChallengeLogRepositoryImpl.java
+++ b/src/main/java/com/moyeo/backend/challenge/log/infrastructure/repository/CustomChallengeLogRepositoryImpl.java
@@ -1,13 +1,17 @@
 package com.moyeo.backend.challenge.log.infrastructure.repository;
 
+import com.moyeo.backend.challenge.log.application.dto.ChallengeLogDailyAggregateDto;
 import com.moyeo.backend.challenge.log.application.dto.ChallengeLogReadRequestDto;
 import com.moyeo.backend.challenge.log.application.dto.ChallengeLogReadResponseDto;
+import com.moyeo.backend.challenge.log.application.dto.QChallengeLogDailyAggregateDto;
 import com.moyeo.backend.challenge.log.application.mapper.ChallengeLogMapper;
 import com.moyeo.backend.challenge.log.domain.ChallengeLog;
 import com.moyeo.backend.challenge.log.domain.ChallengeLogStatus;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +19,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -66,6 +71,30 @@ public class CustomChallengeLogRepositoryImpl implements CustomChallengeLogRepos
         );
     }
 
+    @Override
+    public List<ChallengeLogDailyAggregateDto> aggregateDailyByUser(LocalDate date) {
+
+        BooleanBuilder booleanBuilder = booleanBuilder(date);
+
+        NumberExpression<Integer> totalMinutes = Expressions.numberTemplate(
+                Integer.class,
+                "COALESCE(SUM(FLOOR(EXTRACT(EPOCH FROM ({0} - {1})) / 60.0)::int), 0)::int",
+                challengeLog.updatedAt, challengeLog.createdAt
+        );
+
+        return jpaQueryFactory.select(new QChallengeLogDailyAggregateDto(
+                challengeParticipation.user.id,
+                        challengeLog.date,
+                        totalMinutes
+                ))
+                .from(challengeLog)
+                .join(challengeLog.participation, challengeParticipation)
+                .join(challengeParticipation.user, user)
+                .where(booleanBuilder)
+                .groupBy(challengeParticipation.user.id, challengeLog.date)
+                .fetch();
+    }
+
     private BooleanBuilder booleanBuilder(String challengeId, ChallengeLogReadRequestDto requestDto) {
 
         return new BooleanBuilder()
@@ -73,6 +102,15 @@ public class CustomChallengeLogRepositoryImpl implements CustomChallengeLogRepos
                 .and(challengeIsDeletedFalse())
                 .and(eqChallenge(challengeId))
                 .and(eqStatus(requestDto.getStatus()));
+    }
+
+    private BooleanBuilder booleanBuilder(LocalDate date) {
+
+        return new BooleanBuilder()
+                .and(isDeletedFalse())
+                .and(challengeIsDeletedFalse())
+                .and(eqDate(date))
+                .and(eqStatus(ChallengeLogStatus.SUCCESS));
     }
 
     private BooleanExpression isDeletedFalse() {
@@ -89,5 +127,9 @@ public class CustomChallengeLogRepositoryImpl implements CustomChallengeLogRepos
 
     private BooleanExpression eqStatus(ChallengeLogStatus status) {
         return status != null ? challengeLog.status.eq(status) : null;
+    }
+
+    private BooleanExpression eqDate(LocalDate date) {
+        return challengeLog.date.eq(date);
     }
 }

--- a/src/main/java/com/moyeo/backend/study/application/dto/DailyStudyDto.java
+++ b/src/main/java/com/moyeo/backend/study/application/dto/DailyStudyDto.java
@@ -1,0 +1,19 @@
+package com.moyeo.backend.study.application.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+@Schema(description = "일별 본인 공부 시간 READ RESPONSE DTO")
+public record DailyStudyDto(
+        @Schema(description = "날짜") LocalDate date,
+        @Schema(description = "총 공부 시간 (분)") int totalMinutes)
+{
+    @QueryProjection
+    public DailyStudyDto {
+
+    }
+}

--- a/src/main/java/com/moyeo/backend/study/application/dto/DateRange.java
+++ b/src/main/java/com/moyeo/backend/study/application/dto/DateRange.java
@@ -1,0 +1,9 @@
+package com.moyeo.backend.study.application.dto;
+
+import java.time.LocalDate;
+
+public record DateRange(
+        LocalDate from,
+        LocalDate to
+) {
+}

--- a/src/main/java/com/moyeo/backend/study/application/dto/StudyCalendarReadRequestDto.java
+++ b/src/main/java/com/moyeo/backend/study/application/dto/StudyCalendarReadRequestDto.java
@@ -1,0 +1,26 @@
+package com.moyeo.backend.study.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "일별 본인 공부 시간 목록 REQUEST PARAMETER DTO")
+public class StudyCalendarReadRequestDto {
+
+    @Schema(description = "조회 시작일(yyyy-MM-dd)", example = "2025-08-01")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate from;
+
+    @Schema(description = "조회 종료일(yyyy-MM-dd)", example = "2025-08-31")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate to;
+}

--- a/src/main/java/com/moyeo/backend/study/application/dto/StudyCalendarReadResponseDto.java
+++ b/src/main/java/com/moyeo/backend/study/application/dto/StudyCalendarReadResponseDto.java
@@ -1,0 +1,17 @@
+package com.moyeo.backend.study.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@Schema(description = "일별 본인 공부 시간 목록 READ RESPONSE DTO")
+public class StudyCalendarReadResponseDto {
+    @Schema(description = "일별 본인 공부 시간 (분)")
+    private List<DailyStudyDto> days;
+}

--- a/src/main/java/com/moyeo/backend/study/application/service/StudyService.java
+++ b/src/main/java/com/moyeo/backend/study/application/service/StudyService.java
@@ -1,0 +1,7 @@
+package com.moyeo.backend.study.application.service;
+
+import java.time.LocalDate;
+
+public interface StudyService {
+    void aggregate(LocalDate date);
+}

--- a/src/main/java/com/moyeo/backend/study/application/service/StudyService.java
+++ b/src/main/java/com/moyeo/backend/study/application/service/StudyService.java
@@ -1,7 +1,12 @@
 package com.moyeo.backend.study.application.service;
 
+import com.moyeo.backend.study.application.dto.StudyCalendarReadRequestDto;
+import com.moyeo.backend.study.application.dto.StudyCalendarReadResponseDto;
+
 import java.time.LocalDate;
 
 public interface StudyService {
     void aggregate(LocalDate date);
+
+    StudyCalendarReadResponseDto getCalendar(StudyCalendarReadRequestDto requestDto);
 }

--- a/src/main/java/com/moyeo/backend/study/application/service/StudyServiceImpl.java
+++ b/src/main/java/com/moyeo/backend/study/application/service/StudyServiceImpl.java
@@ -1,15 +1,26 @@
 package com.moyeo.backend.study.application.service;
 
+import com.moyeo.backend.auth.application.service.UserContextService;
 import com.moyeo.backend.challenge.log.application.dto.ChallengeLogDailyAggregateDto;
 import com.moyeo.backend.challenge.log.domain.ChallengeLogRepository;
+import com.moyeo.backend.study.application.dto.DailyStudyDto;
+import com.moyeo.backend.study.application.dto.DateRange;
+import com.moyeo.backend.study.application.dto.StudyCalendarReadRequestDto;
+import com.moyeo.backend.study.application.dto.StudyCalendarReadResponseDto;
+import com.moyeo.backend.study.application.validator.StudyCalendarValidator;
 import com.moyeo.backend.study.domain.StudyCalendarRepository;
+import com.moyeo.backend.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j(topic = "StudyService")
 @Service
@@ -18,6 +29,9 @@ public class StudyServiceImpl implements StudyService {
 
     private final ChallengeLogRepository logRepository;
     private final StudyCalendarRepository studyCalendarRepository;
+    private final UserContextService userContextService;
+    private final StudyCalendarValidator calendarValidator;
+
 
     @Override
     @Transactional
@@ -26,5 +40,41 @@ public class StudyServiceImpl implements StudyService {
         log.info("총 공부 시간 집계 완료, data = {}", list);
         if (list.isEmpty()) return;
         studyCalendarRepository.upsertAll(list);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public StudyCalendarReadResponseDto getCalendar(StudyCalendarReadRequestDto requestDto) {
+        User currentUser = userContextService.getCurrentUser();
+        String userId = currentUser.getId();
+
+        DateRange range = calendarValidator.rangeForCalendar(requestDto);
+        if (range.from() == null) {
+            return StudyCalendarReadResponseDto.builder()
+                    .days(Collections.emptyList())
+                    .build();
+        }
+
+        LocalDate from = range.from();
+        LocalDate to = range.to();
+
+        List<DailyStudyDto> list = studyCalendarRepository.findDailyTotals(userId, from, to);
+        List<DailyStudyDto> days = fillMissingWithZero(from, to, list);
+
+        return StudyCalendarReadResponseDto.builder()
+                .days(days)
+                .build();
+    }
+
+    private List<DailyStudyDto> fillMissingWithZero(LocalDate from, LocalDate to, List<DailyStudyDto> list) {
+        Map<LocalDate, Integer> byDate = list.stream()
+                .collect(Collectors.toMap(DailyStudyDto::date, DailyStudyDto::totalMinutes, (a, b) -> a));
+
+        List<DailyStudyDto> result = new ArrayList<>();
+        for (LocalDate date = from; !date.isAfter(to); date = date.plusDays(1)) {
+            int minutes = byDate.getOrDefault(date, 0);
+            result.add(DailyStudyDto.builder().date(date).totalMinutes(minutes).build());
+        }
+        return result;
     }
 }

--- a/src/main/java/com/moyeo/backend/study/application/service/StudyServiceImpl.java
+++ b/src/main/java/com/moyeo/backend/study/application/service/StudyServiceImpl.java
@@ -1,0 +1,30 @@
+package com.moyeo.backend.study.application.service;
+
+import com.moyeo.backend.challenge.log.application.dto.ChallengeLogDailyAggregateDto;
+import com.moyeo.backend.challenge.log.domain.ChallengeLogRepository;
+import com.moyeo.backend.study.domain.StudyCalendarRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j(topic = "StudyService")
+@Service
+@RequiredArgsConstructor
+public class StudyServiceImpl implements StudyService {
+
+    private final ChallengeLogRepository logRepository;
+    private final StudyCalendarRepository studyCalendarRepository;
+
+    @Override
+    @Transactional
+    public void aggregate(LocalDate date) {
+        List<ChallengeLogDailyAggregateDto> list = logRepository.aggregateDailyByUser(date);
+        log.info("총 공부 시간 집계 완료, data = {}", list);
+        if (list.isEmpty()) return;
+        studyCalendarRepository.upsertAll(list);
+    }
+}

--- a/src/main/java/com/moyeo/backend/study/application/validator/StudyCalendarValidator.java
+++ b/src/main/java/com/moyeo/backend/study/application/validator/StudyCalendarValidator.java
@@ -1,0 +1,25 @@
+package com.moyeo.backend.study.application.validator;
+
+import com.moyeo.backend.study.application.dto.DateRange;
+import com.moyeo.backend.study.application.dto.StudyCalendarReadRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class StudyCalendarValidator {
+
+    public DateRange rangeForCalendar(StudyCalendarReadRequestDto requestDto) {
+        LocalDate cap = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
+
+        LocalDate to = Optional.ofNullable(requestDto.getTo()).orElse(cap);
+        if (to.isAfter(cap)) to = cap;
+
+        LocalDate from = Optional.ofNullable(requestDto.getFrom()).orElse(to.withDayOfMonth(1));
+        return from.isAfter(to) ? new DateRange(null, null) : new DateRange(from, to);
+    }
+}

--- a/src/main/java/com/moyeo/backend/study/domain/StudyCalendar.java
+++ b/src/main/java/com/moyeo/backend/study/domain/StudyCalendar.java
@@ -1,0 +1,32 @@
+package com.moyeo.backend.study.domain;
+
+import com.moyeo.backend.common.domain.BaseEntity;
+import com.moyeo.backend.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "study_calendar",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "date"}))
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StudyCalendar extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    @Column(nullable = false)
+    private int totalMinutes;
+}

--- a/src/main/java/com/moyeo/backend/study/domain/StudyCalendarRepository.java
+++ b/src/main/java/com/moyeo/backend/study/domain/StudyCalendarRepository.java
@@ -1,10 +1,14 @@
 package com.moyeo.backend.study.domain;
 
 import com.moyeo.backend.challenge.log.application.dto.ChallengeLogDailyAggregateDto;
+import com.moyeo.backend.study.application.dto.DailyStudyDto;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface StudyCalendarRepository {
 
     void upsertAll(List<ChallengeLogDailyAggregateDto> list);
+
+    List<DailyStudyDto> findDailyTotals(String userId, LocalDate from, LocalDate to);
 }

--- a/src/main/java/com/moyeo/backend/study/domain/StudyCalendarRepository.java
+++ b/src/main/java/com/moyeo/backend/study/domain/StudyCalendarRepository.java
@@ -1,0 +1,4 @@
+package com.moyeo.backend.study.domain;
+
+public interface StudyCalendarRepository {
+}

--- a/src/main/java/com/moyeo/backend/study/infrastructure/batch/StudyBatchConfig.java
+++ b/src/main/java/com/moyeo/backend/study/infrastructure/batch/StudyBatchConfig.java
@@ -1,0 +1,35 @@
+package com.moyeo.backend.study.infrastructure.batch;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.launch.support.RunIdIncrementer;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+
+@Configuration
+@RequiredArgsConstructor
+public class StudyBatchConfig {
+
+    private final JobRepository jobRepository;
+    private final PlatformTransactionManager transactionManager;
+
+    @Bean
+    public Step aggregateStudyStep(StudyTasklet tasklet) {
+        return new StepBuilder("aggregateStudyStep", jobRepository)
+                .tasklet(tasklet, transactionManager)
+                .build();
+    }
+
+    @Bean
+    public Job studyCalendarJob(Step studyCalendarJob) {
+        return new JobBuilder("studyCalendarJob", jobRepository)
+                .incrementer(new RunIdIncrementer())
+                .start(studyCalendarJob)
+                .build();
+    }
+}

--- a/src/main/java/com/moyeo/backend/study/infrastructure/batch/StudyBatchScheduler.java
+++ b/src/main/java/com/moyeo/backend/study/infrastructure/batch/StudyBatchScheduler.java
@@ -1,0 +1,39 @@
+package com.moyeo.backend.study.infrastructure.batch;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StudyBatchScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job studyCalendarJob;
+
+    @Scheduled(cron = "0 1 0 * * *", zone = "Asia/Seoul")
+    public void runForStudy() {
+        LocalDate target = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
+
+        JobParameters jobParameters = new JobParametersBuilder()
+                .addString("targetDate", target.toString())
+                .addLong("ts", System.currentTimeMillis())
+                .toJobParameters();
+
+        try {
+            jobLauncher.run(studyCalendarJob, jobParameters);
+            log.info("[Batch] 총 공부 시간 업데이트 스케줄러 작동 date = {}", target);
+        } catch (Exception e) {
+            log.error("[Batch] 총 공부 시간 업데이트 스케줄러 작동 실패 date = {}", target, e);
+        }
+    }
+}

--- a/src/main/java/com/moyeo/backend/study/infrastructure/batch/StudyTasklet.java
+++ b/src/main/java/com/moyeo/backend/study/infrastructure/batch/StudyTasklet.java
@@ -1,0 +1,34 @@
+package com.moyeo.backend.study.infrastructure.batch;
+
+import com.moyeo.backend.study.application.service.StudyService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+
+@Slf4j(topic = "StudyTasklet")
+@Component
+@StepScope
+@RequiredArgsConstructor
+public class StudyTasklet implements Tasklet {
+
+    private final StudyService studyService;
+
+    @Value("#{jobParameters['targetDate']}")
+    private String targetDate;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
+        LocalDate date = LocalDate.parse(targetDate);
+        studyService.aggregate(date);
+        log.info("[Batch] 총 공부 시간 업데이트 배치 완료 date = {}", date);
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/com/moyeo/backend/study/infrastructure/repository/CustomStudyCalendarRepository.java
+++ b/src/main/java/com/moyeo/backend/study/infrastructure/repository/CustomStudyCalendarRepository.java
@@ -1,0 +1,11 @@
+package com.moyeo.backend.study.infrastructure.repository;
+
+import com.moyeo.backend.study.application.dto.DailyStudyDto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface CustomStudyCalendarRepository {
+    List<DailyStudyDto> findDailyTotals(String userId, LocalDate from, LocalDate to);
+
+}

--- a/src/main/java/com/moyeo/backend/study/infrastructure/repository/CustomStudyCalendarRepositoryImpl.java
+++ b/src/main/java/com/moyeo/backend/study/infrastructure/repository/CustomStudyCalendarRepositoryImpl.java
@@ -1,0 +1,52 @@
+package com.moyeo.backend.study.infrastructure.repository;
+
+import com.moyeo.backend.study.application.dto.DailyStudyDto;
+import com.moyeo.backend.study.application.dto.QDailyStudyDto;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static com.moyeo.backend.study.domain.QStudyCalendar.studyCalendar;
+
+@RequiredArgsConstructor
+public class CustomStudyCalendarRepositoryImpl implements CustomStudyCalendarRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<DailyStudyDto> findDailyTotals(String userId, LocalDate from, LocalDate to) {
+        BooleanBuilder booleanBuilder = booleanBuilder(userId, from, to);
+
+        return jpaQueryFactory.select(new QDailyStudyDto(
+                studyCalendar.date,
+                studyCalendar.totalMinutes))
+                .from(studyCalendar)
+                .where(booleanBuilder)
+                .orderBy(studyCalendar.date.asc())
+                .fetch();
+    }
+
+    private BooleanBuilder booleanBuilder(String userId, LocalDate from, LocalDate to) {
+        return  new BooleanBuilder()
+                .and(isDeletedFalse())
+                .and(eqUser(userId))
+                .and(betweenDate(from, to));
+    }
+
+    private BooleanExpression isDeletedFalse() {
+        return studyCalendar.isDeleted.isFalse();
+    }
+
+    private BooleanExpression eqUser(String userId) {
+        return studyCalendar.user.id.eq(userId);
+    }
+
+    private BooleanExpression betweenDate(LocalDate from, LocalDate to) {
+        return studyCalendar.date.between(from, to);
+    }
+
+}

--- a/src/main/java/com/moyeo/backend/study/infrastructure/repository/JpaStudyCalendarRepository.java
+++ b/src/main/java/com/moyeo/backend/study/infrastructure/repository/JpaStudyCalendarRepository.java
@@ -10,6 +10,5 @@ import java.util.UUID;
 @Repository
 public interface JpaStudyCalendarRepository extends
         StudyCalendarRepository, JpaRepository<StudyCalendar, UUID>,
-        StudyCalendarUpsertRepository {
-
+        StudyCalendarUpsertRepository, CustomStudyCalendarRepository {
 }

--- a/src/main/java/com/moyeo/backend/study/infrastructure/repository/JpaStudyCalendarRepository.java
+++ b/src/main/java/com/moyeo/backend/study/infrastructure/repository/JpaStudyCalendarRepository.java
@@ -1,0 +1,15 @@
+package com.moyeo.backend.study.infrastructure.repository;
+
+import com.moyeo.backend.study.domain.StudyCalendar;
+import com.moyeo.backend.study.domain.StudyCalendarRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface JpaStudyCalendarRepository extends
+        StudyCalendarRepository, JpaRepository<StudyCalendar, UUID>,
+        StudyCalendarUpsertRepository {
+
+}

--- a/src/main/java/com/moyeo/backend/study/infrastructure/repository/StudyCalendarUpsertRepository.java
+++ b/src/main/java/com/moyeo/backend/study/infrastructure/repository/StudyCalendarUpsertRepository.java
@@ -1,10 +1,10 @@
-package com.moyeo.backend.study.domain;
+package com.moyeo.backend.study.infrastructure.repository;
 
 import com.moyeo.backend.challenge.log.application.dto.ChallengeLogDailyAggregateDto;
 
 import java.util.List;
 
-public interface StudyCalendarRepository {
+public interface StudyCalendarUpsertRepository {
 
     void upsertAll(List<ChallengeLogDailyAggregateDto> list);
 }

--- a/src/main/java/com/moyeo/backend/study/infrastructure/repository/StudyCalendarUpsertRepositoryImpl.java
+++ b/src/main/java/com/moyeo/backend/study/infrastructure/repository/StudyCalendarUpsertRepositoryImpl.java
@@ -1,0 +1,70 @@
+package com.moyeo.backend.study.infrastructure.repository;
+
+import com.moyeo.backend.challenge.log.application.dto.ChallengeLogDailyAggregateDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class StudyCalendarUpsertRepositoryImpl implements StudyCalendarUpsertRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final AuditorAware<String> auditorAware;
+
+    private static final int BATCH_SIZE = 500;
+    private static final String SQL = """
+        INSERT INTO study_calendar (
+            id,
+            user_id, date, total_minutes,
+            created_at, created_by,
+            updated_at, updated_by,
+            is_deleted
+        )
+        VALUES (
+            :id,
+            :userId, :date, :totalMinutes,
+            :now,    :actor,
+            :now,    :actor,
+            false
+        )
+        ON CONFLICT (user_id, date)
+        DO UPDATE SET
+            total_minutes = EXCLUDED.total_minutes,
+            updated_at    = EXCLUDED.updated_at,
+            updated_by    = EXCLUDED.updated_by
+        """;
+
+    @Override
+    public void upsertAll(List<ChallengeLogDailyAggregateDto> list) {
+        final String actor = auditorAware.getCurrentAuditor().orElse("SYSTEM");
+        final LocalDateTime now =  LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+
+         List<SqlParameterSource> buffer = new ArrayList<>(BATCH_SIZE);
+
+         for (ChallengeLogDailyAggregateDto c : list) {
+             buffer.add(new MapSqlParameterSource()
+                     .addValue("id", UUID.randomUUID().toString())
+                     .addValue("userId", c.userId())
+                     .addValue("date", c.date())
+                     .addValue("totalMinutes", c.totalMinutes())
+                     .addValue("actor",  actor)
+                     .addValue("now",    now));
+
+             if (buffer.size() == BATCH_SIZE) {
+                 jdbcTemplate.batchUpdate(SQL, buffer.toArray(SqlParameterSource[]::new));
+                 buffer.clear();
+             }
+         }
+        if (!buffer.isEmpty()) {
+            jdbcTemplate.batchUpdate(SQL, buffer.toArray(SqlParameterSource[]::new));
+        }
+    }
+}

--- a/src/main/java/com/moyeo/backend/study/presentation/StudyController.java
+++ b/src/main/java/com/moyeo/backend/study/presentation/StudyController.java
@@ -1,0 +1,32 @@
+package com.moyeo.backend.study.presentation;
+
+import com.moyeo.backend.common.response.ApiResponse;
+import com.moyeo.backend.study.application.service.StudyService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+
+@Slf4j(topic = "StudyController")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/studies")
+public class StudyController implements StudyControllerDocs {
+
+    private final StudyService studyService;
+
+    @PostMapping("/aggregate")
+    public ResponseEntity<ApiResponse<Void>> aggreate(
+            @RequestParam LocalDate from, @RequestParam LocalDate to) {
+        for (LocalDate date = from; !date.isAfter(to); date = date.plusDays(1)) {
+            studyService.aggregate(date);
+        }
+        log.info("(Admin) 총 공부 시간 집계 Admin 으로 실행, from = {}, to = {}", from, to);
+        return ResponseEntity.ok().body(ApiResponse.success());
+    }
+}

--- a/src/main/java/com/moyeo/backend/study/presentation/StudyController.java
+++ b/src/main/java/com/moyeo/backend/study/presentation/StudyController.java
@@ -1,14 +1,14 @@
 package com.moyeo.backend.study.presentation;
 
 import com.moyeo.backend.common.response.ApiResponse;
+import com.moyeo.backend.study.application.dto.StudyCalendarReadRequestDto;
+import com.moyeo.backend.study.application.dto.StudyCalendarReadResponseDto;
 import com.moyeo.backend.study.application.service.StudyService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 
@@ -28,5 +28,12 @@ public class StudyController implements StudyControllerDocs {
         }
         log.info("(Admin) 총 공부 시간 집계 Admin 으로 실행, from = {}, to = {}", from, to);
         return ResponseEntity.ok().body(ApiResponse.success());
+    }
+
+    @Override
+    @GetMapping("/days")
+    public ResponseEntity<ApiResponse<StudyCalendarReadResponseDto>> getCalendar(
+            @ParameterObject @ModelAttribute StudyCalendarReadRequestDto requestDto) {
+        return ResponseEntity.ok().body(ApiResponse.success(studyService.getCalendar(requestDto)));
     }
 }

--- a/src/main/java/com/moyeo/backend/study/presentation/StudyControllerDocs.java
+++ b/src/main/java/com/moyeo/backend/study/presentation/StudyControllerDocs.java
@@ -1,0 +1,17 @@
+package com.moyeo.backend.study.presentation;
+
+import com.moyeo.backend.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import java.time.LocalDate;
+
+@Tag(name = "스터디 관련 API Controller", description = "스터디 관련 API 목록입니다.")
+@SecurityRequirement(name = "bearerAuth")
+public interface StudyControllerDocs {
+
+    @Operation(summary = "[ADMIN] 총 공부 시간 집계 API", description = "[ADMIN] 총 공부 시간 집계 API 입니다.")
+    ResponseEntity<ApiResponse<Void>> aggreate(LocalDate from, LocalDate to);
+}

--- a/src/main/java/com/moyeo/backend/study/presentation/StudyControllerDocs.java
+++ b/src/main/java/com/moyeo/backend/study/presentation/StudyControllerDocs.java
@@ -1,6 +1,8 @@
 package com.moyeo.backend.study.presentation;
 
 import com.moyeo.backend.common.response.ApiResponse;
+import com.moyeo.backend.study.application.dto.StudyCalendarReadRequestDto;
+import com.moyeo.backend.study.application.dto.StudyCalendarReadResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -14,4 +16,8 @@ public interface StudyControllerDocs {
 
     @Operation(summary = "[ADMIN] 총 공부 시간 집계 API", description = "[ADMIN] 총 공부 시간 집계 API 입니다.")
     ResponseEntity<ApiResponse<Void>> aggreate(LocalDate from, LocalDate to);
+
+    @Operation(summary = "일별 본인 공부 시간 목록 조회 API", description = "일별 본인 공부 시간 목록 조회 API 입니다.")
+    ResponseEntity<ApiResponse<StudyCalendarReadResponseDto>> getCalendar(StudyCalendarReadRequestDto requestDto);
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,6 +42,11 @@ spring:
   messages:
     basename: validation-messages-ko
     encoding: UTF-8
+  batch:
+    job:
+      enabled: false
+    jdbc:
+      initialize-schema: always
 
 jwt:
   secret:


### PR DESCRIPTION
📌 Summary
<!-- 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- Jira 이슈 키를 포함하면 자동 연동됩니다 -->

- Related Jira Issue: [MOYEO-73]

✅ Key Changes
<!-- 주요 변경 사항 bullet 형식으로 작성 -->
- 사용자별 하루 공부 시간 집계 함수 구현
  - QueryDSL 로 사용자, 날짜 기준으로 하루 공부 시간 집계
  [공부 시간 게산]
    - 공부 시작 시간 = 키워드 입력 시간 = ChallengeLog 생성 시간 (createdAt)
    - 공부 종료 시간 = 내용 입력 시간 = ChallengeLog 수정 시간 (updateAt)
    - 챌린지별(ChallengeLog) 총 공부 시간 = 공부 종료 시간 - 공부 시작 시간
    - 하루 총 공부 시간 = 챌린지별 총 공부 시간의 합(SUM)
- 사용자별 총 공부 시간 업데이트 배치 로직 구현
  - Spring Batch 적용
    - Job: 사용자별 총 공부 시간 집계 후 테이블에 반영
    - Step: 집계 결과 조회 후 Upsert (Tasklet 실행)
    - JobParameters: targetDate + ts 로 중복 실행 방지
  - 스케줄러: 매일 00:01 에 전날 데이터 반영 (StudyCalendar)
  - 네이티브 쿼리 (JDBC) upsert 로 insert + update 동시 처리 (배치 크기 500)
  - /studies/aggregate 로 Admin 용 집계 API 로 확인
- 일별 본인 공부 시간 목록 조회 API 구현
  - from, to 파라미터로 목록 조회 범위 설정
  - 오늘/미래 날짜 포함 조회시, 오늘 전날까지로 범위 자동 조정
  - 조회 데이터가 없는 경우 공부 시간 0으로 채워서 반환

🧪 Testing
<!-- 어떻게 테스트했는지 설명 -->
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 포스트맨 응답 테스트
  - 총 공부 시간 집계 (스케줄러 대신 API 응답으로 집계 데이터 확인)
    <img width="1442" height="382" alt="image" src="https://github.com/user-attachments/assets/ec7afd20-3203-435a-a08e-0c85524865d9" />
  - 일별 공부 시간 목록 조회 (파라미터 X)
    <img width="2024" height="1772" alt="image" src="https://github.com/user-attachments/assets/5c23476e-27b4-4a00-b3c2-e61d81ed03d0" />
  - 일별 공부 시간 목록 조회 (파라미터 O)
    <img width="2026" height="1766" alt="image" src="https://github.com/user-attachments/assets/cf1b4f25-c422-4dde-a0db-37f077570bb0" />

🙋 To Reviewers
<!-- 리뷰어에게 알리고 싶은 내용 -->
- 스케줄러 확인 테스트는 추후에 진행해보도록 하겠습니다.
- 조회 API 파라미터 없이 요청시 현재 월의 공부 시간 목록(오늘 전날까지의) 반환
- 주간 목록 조회 활용 시, 조회 API 파라미터 설정 예시
  - from: 2025-08-19
  - to: 2025-08-24

@coderabbitai 한글 답변 부탁드립니다.