### PR TITLE
Feat: [사용자 관리] 주간 학습 통계 조회 API 구현 (MOYEO-74)

### DIFF
--- a/src/main/java/com/moyeo/backend/routine/application/dto/RoutineStatReadRequestDto.java
+++ b/src/main/java/com/moyeo/backend/routine/application/dto/RoutineStatReadRequestDto.java
@@ -1,0 +1,22 @@
+package com.moyeo.backend.routine.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Builder
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "주간 학습 통계 REQUEST PARAMETER DTO")
+public class RoutineStatReadRequestDto {
+
+    @Schema(description = "조회 날짜(yyyy-MM-dd)", example = "2025-08-01")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate date;
+}

--- a/src/main/java/com/moyeo/backend/routine/application/dto/RoutineStatReadResponseDto.java
+++ b/src/main/java/com/moyeo/backend/routine/application/dto/RoutineStatReadResponseDto.java
@@ -1,0 +1,20 @@
+package com.moyeo.backend.routine.application.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+@Schema(description = "주간 학습 통계 READ RESPONSE DTO")
+public record RoutineStatReadResponseDto(
+        @Schema(description = "사용자 ID") String userId,
+        @Schema(description = "주차 시작 날짜 (월요일)") LocalDate startDate,
+        @Schema(description = "주간 총 공부 시간 (분)") int totalMinutes,
+        @Schema(description = "하루 평균 공부 시간 (분)") int avgMinutes,
+        @Schema(description = "집중 요일") DayOfWeek focusDay,
+        @Schema(description = "가장 적게 공부한 요일") DayOfWeek leastDay,
+        @Schema(description = "출석률 높은 요일") List<DayOfWeek> highAttendanceDays
+) {}

--- a/src/main/java/com/moyeo/backend/routine/application/mapper/RoutineStatMapper.java
+++ b/src/main/java/com/moyeo/backend/routine/application/mapper/RoutineStatMapper.java
@@ -1,0 +1,15 @@
+package com.moyeo.backend.routine.application.mapper;
+
+import com.moyeo.backend.routine.application.dto.RoutineStatReadResponseDto;
+import com.moyeo.backend.routine.domain.RoutineStat;
+import org.mapstruct.Mapper;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+@Mapper(
+        componentModel = "spring",
+        nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE
+)
+public interface RoutineStatMapper {
+
+    RoutineStatReadResponseDto toRoutineStatDto(RoutineStat routineStat);
+}

--- a/src/main/java/com/moyeo/backend/routine/application/service/RoutineService.java
+++ b/src/main/java/com/moyeo/backend/routine/application/service/RoutineService.java
@@ -1,0 +1,9 @@
+package com.moyeo.backend.routine.application.service;
+
+import com.moyeo.backend.routine.application.dto.RoutineStatReadRequestDto;
+import com.moyeo.backend.routine.application.dto.RoutineStatReadResponseDto;
+
+public interface RoutineService {
+
+    RoutineStatReadResponseDto getRoutineStat(RoutineStatReadRequestDto requestDto);
+}

--- a/src/main/java/com/moyeo/backend/routine/application/service/RoutineServiceImpl.java
+++ b/src/main/java/com/moyeo/backend/routine/application/service/RoutineServiceImpl.java
@@ -1,0 +1,45 @@
+package com.moyeo.backend.routine.application.service;
+
+import com.moyeo.backend.auth.application.service.UserContextService;
+import com.moyeo.backend.routine.application.dto.RoutineStatReadRequestDto;
+import com.moyeo.backend.routine.application.dto.RoutineStatReadResponseDto;
+import com.moyeo.backend.routine.application.mapper.RoutineStatMapper;
+import com.moyeo.backend.routine.domain.RoutineStat;
+import com.moyeo.backend.routine.domain.RoutineStatRepository;
+import com.moyeo.backend.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import static java.time.temporal.TemporalAdjusters.previousOrSame;
+
+@Slf4j(topic = "RoutineStatService")
+@Service
+@RequiredArgsConstructor
+public class RoutineServiceImpl implements RoutineService {
+
+    private final UserContextService userContextService;
+    private final RoutineStatRepository routineStatRepository;
+    private final RoutineStatMapper routineStatMapper;
+
+    @Override
+    @Transactional(readOnly = true)
+    public RoutineStatReadResponseDto getRoutineStat(RoutineStatReadRequestDto requestDto) {
+        User currentUser = userContextService.getCurrentUser();
+        String userId = currentUser.getId();
+
+        LocalDate startDate = requestDto.getDate() == null ?
+                LocalDate.now(ZoneId.of("Asia/Seoul")).with(previousOrSame(DayOfWeek.MONDAY)).minusWeeks(1)
+                : requestDto.getDate().with(previousOrSame(DayOfWeek.MONDAY));
+
+        RoutineStat routineStat = routineStatRepository.findByUserIdAndStartDateAndIsDeletedFalse(userId, startDate)
+                .orElse(null);
+
+        return routineStatMapper.toRoutineStatDto(routineStat);
+    }
+}

--- a/src/main/java/com/moyeo/backend/routine/domain/RoutineStat.java
+++ b/src/main/java/com/moyeo/backend/routine/domain/RoutineStat.java
@@ -1,0 +1,51 @@
+package com.moyeo.backend.routine.domain;
+
+import com.moyeo.backend.common.domain.BaseEntity;
+import com.moyeo.backend.user.domain.User;
+import com.vladmihalcea.hibernate.type.json.JsonType;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Type;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+
+@Entity
+@Table(name = "routine_stat",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "start_date"}))
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RoutineStat extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private int totalMinutes;
+
+    @Column(nullable = false)
+    private int avgMinutes;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private DayOfWeek focusDay;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private DayOfWeek leastDay;
+
+    @Column(nullable = false, columnDefinition = "jsonb")
+    @Type(JsonType.class)
+    private List<DayOfWeek> highAttendanceDays;
+}

--- a/src/main/java/com/moyeo/backend/routine/domain/RoutineStatRepository.java
+++ b/src/main/java/com/moyeo/backend/routine/domain/RoutineStatRepository.java
@@ -1,0 +1,4 @@
+package com.moyeo.backend.routine.domain;
+
+public interface RoutineStatRepository {
+}

--- a/src/main/java/com/moyeo/backend/routine/domain/RoutineStatRepository.java
+++ b/src/main/java/com/moyeo/backend/routine/domain/RoutineStatRepository.java
@@ -2,8 +2,12 @@ package com.moyeo.backend.routine.domain;
 
 import com.moyeo.backend.routine.application.dto.RoutineStatReadResponseDto;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface RoutineStatRepository {
     void upsertAll(List<RoutineStatReadResponseDto> stats);
+
+    Optional<RoutineStat> findByUserIdAndStartDateAndIsDeletedFalse(String userId, LocalDate startDate);
 }

--- a/src/main/java/com/moyeo/backend/routine/infrastructure/JpaRoutineStatRepository.java
+++ b/src/main/java/com/moyeo/backend/routine/infrastructure/JpaRoutineStatRepository.java
@@ -8,5 +8,7 @@ import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
-public interface JpaRoutineStatRepository extends RoutineStatRepository, JpaRepository<RoutineStat, UUID> {
+public interface JpaRoutineStatRepository extends
+        RoutineStatRepository, JpaRepository<RoutineStat, UUID>,
+        RoutineStatUpsertRepository {
 }

--- a/src/main/java/com/moyeo/backend/routine/infrastructure/JpaRoutineStatRepository.java
+++ b/src/main/java/com/moyeo/backend/routine/infrastructure/JpaRoutineStatRepository.java
@@ -1,0 +1,12 @@
+package com.moyeo.backend.routine.infrastructure;
+
+import com.moyeo.backend.routine.domain.RoutineStat;
+import com.moyeo.backend.routine.domain.RoutineStatRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface JpaRoutineStatRepository extends RoutineStatRepository, JpaRepository<RoutineStat, UUID> {
+}

--- a/src/main/java/com/moyeo/backend/routine/infrastructure/RoutineStatUpsertRepository.java
+++ b/src/main/java/com/moyeo/backend/routine/infrastructure/RoutineStatUpsertRepository.java
@@ -1,9 +1,10 @@
-package com.moyeo.backend.routine.domain;
+package com.moyeo.backend.routine.infrastructure;
 
 import com.moyeo.backend.routine.application.dto.RoutineStatReadResponseDto;
 
 import java.util.List;
 
-public interface RoutineStatRepository {
+public interface RoutineStatUpsertRepository {
     void upsertAll(List<RoutineStatReadResponseDto> stats);
+
 }

--- a/src/main/java/com/moyeo/backend/routine/infrastructure/RoutineStatUpsertRepositoryImpl.java
+++ b/src/main/java/com/moyeo/backend/routine/infrastructure/RoutineStatUpsertRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.moyeo.backend.routine.infrastructure;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moyeo.backend.routine.application.dto.RoutineStatReadResponseDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -14,6 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j(topic = "RoutineStatUpsertRepositoryImpl")
 @RequiredArgsConstructor
 public class RoutineStatUpsertRepositoryImpl implements RoutineStatUpsertRepository {
 
@@ -64,10 +66,11 @@ public class RoutineStatUpsertRepositoryImpl implements RoutineStatUpsertReposit
                 );
             } catch (Exception e) {
                 highJson = "[]";
+                log.warn("출석률 높은 요일 직렬화 실패, userId={}, startDate={}, e=[]", r.userId(), r.startDate(), e);
             }
 
             buffer.add(new MapSqlParameterSource()
-                    .addValue("id", UUID.randomUUID().toString())
+                    .addValue("id", UUID.randomUUID())
                     .addValue("userId", r.userId())
                     .addValue("startDate", r.startDate())
                     .addValue("totalMinutes", r.totalMinutes())

--- a/src/main/java/com/moyeo/backend/routine/infrastructure/RoutineStatUpsertRepositoryImpl.java
+++ b/src/main/java/com/moyeo/backend/routine/infrastructure/RoutineStatUpsertRepositoryImpl.java
@@ -1,0 +1,91 @@
+package com.moyeo.backend.routine.infrastructure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moyeo.backend.routine.application.dto.RoutineStatReadResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class RoutineStatUpsertRepositoryImpl implements RoutineStatUpsertRepository {
+
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final AuditorAware<String> auditorAware;
+    private final ObjectMapper objectMapper;
+
+    private static final int BATCH_SIZE = 500;
+    private static final String SQL = """
+        INSERT INTO routine_stat (
+            id,
+            user_id, start_date,
+            total_minutes, avg_minutes,
+            focus_day, least_day, high_attendance_days,
+            created_at, created_by, updated_at, updated_by, is_deleted
+        )
+        VALUES (
+            :id,
+            :userId, :startDate,
+            :totalMinutes, :avgMinutes,
+            :focusDay, :leastDay, CAST(:highAttendanceJson AS jsonb),
+            :now, :actor, :now, :actor, false
+        )
+        ON CONFLICT (user_id, start_date)
+        DO UPDATE SET
+            total_minutes = EXCLUDED.total_minutes,
+            avg_minutes   = EXCLUDED.avg_minutes,
+            focus_day     = EXCLUDED.focus_day,
+            least_day     = EXCLUDED.least_day,
+            high_attendance_days = EXCLUDED.high_attendance_days,
+            updated_at    = EXCLUDED.updated_at,
+            updated_by    = EXCLUDED.updated_by,
+            is_deleted    = false
+        """;
+
+    @Override
+    public void upsertAll(List<RoutineStatReadResponseDto> stats) {
+        final String actor = auditorAware.getCurrentAuditor().orElse("SYSTEM");
+        final LocalDateTime now =  LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+
+        List<SqlParameterSource> buffer = new ArrayList<>(BATCH_SIZE);
+
+        for (RoutineStatReadResponseDto r : stats) {
+            String highJson;
+            try {
+                highJson = objectMapper.writeValueAsString(
+                        r.highAttendanceDays().stream().map(Enum::name).toList()
+                );
+            } catch (Exception e) {
+                highJson = "[]";
+            }
+
+            buffer.add(new MapSqlParameterSource()
+                    .addValue("id", UUID.randomUUID().toString())
+                    .addValue("userId", r.userId())
+                    .addValue("startDate", r.startDate())
+                    .addValue("totalMinutes", r.totalMinutes())
+                    .addValue("avgMinutes", r.avgMinutes())
+                    .addValue("focusDay", r.focusDay().name())
+                    .addValue("leastDay", r.leastDay().name())
+                    .addValue("highAttendanceJson", highJson)
+                    .addValue("actor", actor)
+                    .addValue("now", now)
+            );
+
+            if (buffer.size() == BATCH_SIZE) {
+                jdbcTemplate.batchUpdate(SQL, buffer.toArray(SqlParameterSource[]::new));
+                buffer.clear();
+            }
+        }
+        if (!buffer.isEmpty()) {
+            jdbcTemplate.batchUpdate(SQL, buffer.toArray(SqlParameterSource[]::new));
+        }
+    }
+}

--- a/src/main/java/com/moyeo/backend/routine/presentation/RoutineController.java
+++ b/src/main/java/com/moyeo/backend/routine/presentation/RoutineController.java
@@ -1,0 +1,29 @@
+package com.moyeo.backend.routine.presentation;
+
+import com.moyeo.backend.common.response.ApiResponse;
+import com.moyeo.backend.routine.application.service.RoutineService;
+import com.moyeo.backend.routine.application.dto.RoutineStatReadRequestDto;
+import com.moyeo.backend.routine.application.dto.RoutineStatReadResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j(topic = "RoutineStatController")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/routines")
+public class RoutineController implements RoutineControllerDocs {
+
+    private final RoutineService routineService;
+
+    @GetMapping("/stat/me")
+    public ResponseEntity<ApiResponse<RoutineStatReadResponseDto>> getRoutineStat(
+            @ParameterObject @ModelAttribute RoutineStatReadRequestDto requestDto) {
+        return ResponseEntity.ok().body(ApiResponse.success(routineService.getRoutineStat(requestDto)));
+    }
+}

--- a/src/main/java/com/moyeo/backend/routine/presentation/RoutineControllerDocs.java
+++ b/src/main/java/com/moyeo/backend/routine/presentation/RoutineControllerDocs.java
@@ -1,0 +1,18 @@
+package com.moyeo.backend.routine.presentation;
+
+import com.moyeo.backend.common.response.ApiResponse;
+import com.moyeo.backend.routine.application.dto.RoutineStatReadRequestDto;
+import com.moyeo.backend.routine.application.dto.RoutineStatReadResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "학습 통계 관련 API Controller", description = "학습 통계 관련 API 목록입니다.")
+@SecurityRequirement(name = "bearerAuth")
+public interface RoutineControllerDocs {
+
+    @Operation(summary = "본인 주간 학습 통계 조회 API", description = "본인 주간 학습 통계 조회 API 입니다.")
+    ResponseEntity<ApiResponse<RoutineStatReadResponseDto>> getRoutineStat(RoutineStatReadRequestDto requestDto);
+
+}

--- a/src/main/java/com/moyeo/backend/study/application/dto/WeeklyAgg.java
+++ b/src/main/java/com/moyeo/backend/study/application/dto/WeeklyAgg.java
@@ -1,0 +1,18 @@
+package com.moyeo.backend.study.application.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record WeeklyAgg(
+        String userId,
+        LocalDate startDate,
+        int mon, int tue, int wed, int thu, int fri, int sat, int sun,
+        int totalMinutes,
+        int avgMinutes
+) {
+    @QueryProjection
+    public WeeklyAgg {}
+}

--- a/src/main/java/com/moyeo/backend/study/application/service/StudyServiceImpl.java
+++ b/src/main/java/com/moyeo/backend/study/application/service/StudyServiceImpl.java
@@ -4,6 +4,7 @@ import com.moyeo.backend.auth.application.service.UserContextService;
 import com.moyeo.backend.challenge.log.application.dto.ChallengeLogDailyAggregateDto;
 import com.moyeo.backend.challenge.log.domain.ChallengeLogRepository;
 import com.moyeo.backend.routine.application.dto.RoutineStatReadResponseDto;
+import com.moyeo.backend.routine.domain.RoutineStatRepository;
 import com.moyeo.backend.study.application.dto.*;
 import com.moyeo.backend.study.application.validator.StudyCalendarValidator;
 import com.moyeo.backend.study.domain.StudyCalendarRepository;
@@ -31,6 +32,7 @@ public class StudyServiceImpl implements StudyService {
     private final StudyCalendarRepository studyCalendarRepository;
     private final UserContextService userContextService;
     private final StudyCalendarValidator calendarValidator;
+    private final RoutineStatRepository routineStatRepository;
 
     @Override
     @Transactional
@@ -59,6 +61,9 @@ public class StudyServiceImpl implements StudyService {
         List<RoutineStatReadResponseDto> stats = list.stream()
                 .map(this::computeWeeklyAgg)
                 .toList();
+
+        routineStatRepository.upsertAll(stats);
+        log.info("주간 학습 통계 업데이트 완료, weekStart = {}, stats = {}", monday, stats);
     }
 
     private RoutineStatReadResponseDto computeWeeklyAgg(WeeklyAgg agg) {

--- a/src/main/java/com/moyeo/backend/study/application/service/StudyServiceImpl.java
+++ b/src/main/java/com/moyeo/backend/study/application/service/StudyServiceImpl.java
@@ -3,10 +3,8 @@ package com.moyeo.backend.study.application.service;
 import com.moyeo.backend.auth.application.service.UserContextService;
 import com.moyeo.backend.challenge.log.application.dto.ChallengeLogDailyAggregateDto;
 import com.moyeo.backend.challenge.log.domain.ChallengeLogRepository;
-import com.moyeo.backend.study.application.dto.DailyStudyDto;
-import com.moyeo.backend.study.application.dto.DateRange;
-import com.moyeo.backend.study.application.dto.StudyCalendarReadRequestDto;
-import com.moyeo.backend.study.application.dto.StudyCalendarReadResponseDto;
+import com.moyeo.backend.routine.application.dto.RoutineStatReadResponseDto;
+import com.moyeo.backend.study.application.dto.*;
 import com.moyeo.backend.study.application.validator.StudyCalendarValidator;
 import com.moyeo.backend.study.domain.StudyCalendarRepository;
 import com.moyeo.backend.user.domain.User;
@@ -15,12 +13,14 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Slf4j(topic = "StudyService")
 @Service
@@ -32,14 +32,64 @@ public class StudyServiceImpl implements StudyService {
     private final UserContextService userContextService;
     private final StudyCalendarValidator calendarValidator;
 
-
     @Override
     @Transactional
     public void aggregate(LocalDate date) {
         List<ChallengeLogDailyAggregateDto> list = logRepository.aggregateDailyByUser(date);
-        log.info("총 공부 시간 집계 완료, data = {}", list);
+        log.info("총 공부 시간 집계 완료, date = {}", date);
+
+        if (!list.isEmpty()) {
+            studyCalendarRepository.upsertAll(list);
+        } else {
+            log.info("집계 데이터 없음, date = {}", date);
+        }
+
+        if (date.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            log.info("주간 학습 통계 처리 시도, weekEndDate = {}", date);
+            upsertWeeklyStat(date);
+        }
+    }
+
+    private void upsertWeeklyStat(LocalDate weekEndDate) {
+        LocalDate monday = weekEndDate.with(DayOfWeek.MONDAY);
+
+        List<WeeklyAgg> list = studyCalendarRepository.findWeeklyAgg(monday, weekEndDate);
         if (list.isEmpty()) return;
-        studyCalendarRepository.upsertAll(list);
+
+        List<RoutineStatReadResponseDto> stats = list.stream()
+                .map(this::computeWeeklyAgg)
+                .toList();
+    }
+
+    private RoutineStatReadResponseDto computeWeeklyAgg(WeeklyAgg agg) {
+        int[] byDay = new int[]{ agg.mon(), agg.tue(), agg.wed(), agg.thu(), agg.fri(), agg.sat(), agg.sun() };
+        int maxIdx = IntStream.range(1, 7)
+                .reduce(0, (best, i) -> byDay[i] > byDay[best] ? i : best);   // 동률이면 기존 best 유지(월→일 우선)
+        int minIdx = IntStream.range(1, 7)
+                .reduce(0, (best, i) -> byDay[i] < byDay[best] ? i : best);
+
+        DayOfWeek focusDay = DayOfWeek.values()[maxIdx];
+        DayOfWeek leastDay = DayOfWeek.values()[minIdx];
+        List<DayOfWeek> highAttendanceDays = IntStream.range(0, 7)
+                .boxed()
+                .filter(i -> byDay[i] > 0)
+                .sorted((a, b) -> {
+                    int cmp = Integer.compare(byDay[b], byDay[a]);
+                    return (cmp != 0) ? cmp : Integer.compare(a, b);
+                })
+                .limit(3)
+                .map(i -> DayOfWeek.values()[i])
+                .toList();
+
+        return RoutineStatReadResponseDto.builder()
+                .userId(agg.userId())
+                .startDate(agg.startDate())
+                .totalMinutes(agg.totalMinutes())
+                .avgMinutes(agg.avgMinutes())
+                .focusDay(focusDay)
+                .leastDay(leastDay)
+                .highAttendanceDays(highAttendanceDays)
+                .build();
     }
 
     @Override

--- a/src/main/java/com/moyeo/backend/study/domain/StudyCalendarRepository.java
+++ b/src/main/java/com/moyeo/backend/study/domain/StudyCalendarRepository.java
@@ -2,6 +2,7 @@ package com.moyeo.backend.study.domain;
 
 import com.moyeo.backend.challenge.log.application.dto.ChallengeLogDailyAggregateDto;
 import com.moyeo.backend.study.application.dto.DailyStudyDto;
+import com.moyeo.backend.study.application.dto.WeeklyAgg;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -11,4 +12,6 @@ public interface StudyCalendarRepository {
     void upsertAll(List<ChallengeLogDailyAggregateDto> list);
 
     List<DailyStudyDto> findDailyTotals(String userId, LocalDate from, LocalDate to);
+
+    List<WeeklyAgg> findWeeklyAgg(LocalDate monday, LocalDate weekEndDate);
 }

--- a/src/main/java/com/moyeo/backend/study/infrastructure/batch/StudyBatchScheduler.java
+++ b/src/main/java/com/moyeo/backend/study/infrastructure/batch/StudyBatchScheduler.java
@@ -9,6 +9,7 @@ import org.springframework.batch.core.launch.JobLauncher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
 
@@ -31,9 +32,9 @@ public class StudyBatchScheduler {
 
         try {
             jobLauncher.run(studyCalendarJob, jobParameters);
-            log.info("[Batch] 총 공부 시간 업데이트 스케줄러 작동 date = {}", target);
+            log.info("[Batch] 총 공부 시간/주간 학습 집계 업데이트 스케줄러 작동 date = {}", target);
         } catch (Exception e) {
-            log.error("[Batch] 총 공부 시간 업데이트 스케줄러 작동 실패 date = {}", target, e);
+            log.error("[Batch] 총 공부 시간/주간 학습 집계 업데이트 스케줄러 작동 실패 date = {}", target, e);
         }
     }
 }

--- a/src/main/java/com/moyeo/backend/study/infrastructure/batch/StudyTasklet.java
+++ b/src/main/java/com/moyeo/backend/study/infrastructure/batch/StudyTasklet.java
@@ -27,8 +27,9 @@ public class StudyTasklet implements Tasklet {
     @Override
     public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) throws Exception {
         LocalDate date = LocalDate.parse(targetDate);
+        log.info("[Batch] 총 공부 시간/주간 학습 통계 업데이트 배치 시작 date = {}", date);
         studyService.aggregate(date);
-        log.info("[Batch] 총 공부 시간 업데이트 배치 완료 date = {}", date);
+        log.info("[Batch] 총 공부 시간/주간 학습 통계 업데이트 배치 완료 date = {}", date);
         return RepeatStatus.FINISHED;
     }
 }

--- a/src/main/java/com/moyeo/backend/study/infrastructure/repository/CustomStudyCalendarRepository.java
+++ b/src/main/java/com/moyeo/backend/study/infrastructure/repository/CustomStudyCalendarRepository.java
@@ -1,6 +1,7 @@
 package com.moyeo.backend.study.infrastructure.repository;
 
 import com.moyeo.backend.study.application.dto.DailyStudyDto;
+import com.moyeo.backend.study.application.dto.WeeklyAgg;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -8,4 +9,5 @@ import java.util.List;
 public interface CustomStudyCalendarRepository {
     List<DailyStudyDto> findDailyTotals(String userId, LocalDate from, LocalDate to);
 
+    List<WeeklyAgg> findWeeklyAgg(LocalDate monday, LocalDate weekEndDate);
 }

--- a/src/main/java/com/moyeo/backend/study/infrastructure/repository/CustomStudyCalendarRepositoryImpl.java
+++ b/src/main/java/com/moyeo/backend/study/infrastructure/repository/CustomStudyCalendarRepositoryImpl.java
@@ -2,8 +2,12 @@ package com.moyeo.backend.study.infrastructure.repository;
 
 import com.moyeo.backend.study.application.dto.DailyStudyDto;
 import com.moyeo.backend.study.application.dto.QDailyStudyDto;
+import com.moyeo.backend.study.application.dto.QWeeklyAgg;
+import com.moyeo.backend.study.application.dto.WeeklyAgg;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
@@ -30,11 +34,50 @@ public class CustomStudyCalendarRepositoryImpl implements CustomStudyCalendarRep
                 .fetch();
     }
 
+    @Override
+    public List<WeeklyAgg> findWeeklyAgg(LocalDate monday, LocalDate sunday) {
+
+        NumberExpression<Integer> mon = dowSum(1);
+        NumberExpression<Integer> tue = dowSum(2);
+        NumberExpression<Integer> wed = dowSum(3);
+        NumberExpression<Integer> thu = dowSum(4);
+        NumberExpression<Integer> fri = dowSum(5);
+        NumberExpression<Integer> sat = dowSum(6);
+        NumberExpression<Integer> sun = dowSum(7);
+
+        NumberExpression<Integer> totalMinutes = studyCalendar.totalMinutes.sum();
+        NumberExpression<Integer> avgMinutes = totalMinutes.divide(7);
+
+        return jpaQueryFactory.select(new QWeeklyAgg(
+                studyCalendar.user.id,
+                Expressions.constant(monday),
+                mon.coalesce(0), tue.coalesce(0), wed.coalesce(0),
+                thu.coalesce(0), fri.coalesce(0), sat.coalesce(0), sun.coalesce(0),
+                totalMinutes,
+                avgMinutes))
+                .from(studyCalendar)
+                .where(booleanBuilder(monday, sunday))
+                .groupBy(studyCalendar.user.id)
+                .fetch();
+    }
+
+    private NumberExpression<Integer> dowSum(int dow) {
+        return Expressions.numberTemplate(Integer.class,
+                "SUM(CASE WHEN CAST(function('date_part','isodow',{0}) AS int) = {1} THEN {2} ELSE 0 END)",
+                studyCalendar.date, dow, studyCalendar.totalMinutes);
+    }
+
     private BooleanBuilder booleanBuilder(String userId, LocalDate from, LocalDate to) {
         return  new BooleanBuilder()
                 .and(isDeletedFalse())
                 .and(eqUser(userId))
                 .and(betweenDate(from, to));
+    }
+
+    private BooleanBuilder booleanBuilder(LocalDate monday, LocalDate sunday) {
+        return  new BooleanBuilder()
+                .and(isDeletedFalse())
+                .and(betweenDate(monday, sunday));
     }
 
     private BooleanExpression isDeletedFalse() {


### PR DESCRIPTION
📌 Summary
<!-- 어떤 작업이 포함됐는지 요약해주세요 -->
<!-- Jira 이슈 키를 포함하면 자동 연동됩니다 -->

- Related Jira Issue: [MOYEO-74]
- 주간 학습 통계 생성 구현
- 주간 학습 통계 조회 API 구현

✅ Key Changes
<!-- 주요 변경 사항 bullet 형식으로 작성 -->
- 주간 학습 통계 계산 함수 구현
  - QueryDSL 로 사용자, 주간 날짜 기준으로 주간 학습 통계 계산
  [주간 학습 통계 계산]
    - 주간 총 공부 시간 = sum(total_minutes)
    - 하루 평균 공부 시간 = 주간 총 공부 시간 / 7
    - 집중/가장 적게 공부한 요일 = 월 ~ 일 비교 max, min 값
    - 학습 시간 높은 요일 = 월 ~ 일 비교 top 3까지
- 주간 학습 통계 업데이트 배치 로직 구현
  - 기존 총 공부시간 업데이트 배치 로직에 추가 구현
  - 일별 총 공부 시간 계산 후, 일요일이면 주간 통계 업데이트 실행
- 주간 학습 통계 조회 API 구현
  - 날짜 파라미터 입력시, 날짜 포함하는 주 통계 응답
  - 날짜 파라미터 미입력시, 이전주 통계 응답

🧪 Testing
<!-- 어떻게 테스트했는지 설명 -->
<!-- 해당 작업을 확인할 수 있는 방법을 기재해주세요 -->
<!-- 전/후 스크린샷을 첨부하기도 합니다 -->
- 주간 학습 통계 DB 생성
  <img width="1152" height="892" alt="image" src="https://github.com/user-attachments/assets/2017d40e-2571-489f-9768-795bd68f9eec" />

- 포스트맨 응답 테스트
  <img width="2032" height="1618" alt="image" src="https://github.com/user-attachments/assets/e5dfa8a6-3044-433a-b7d3-ffa27798285a" />


🙋 To Reviewers
<!-- 리뷰어에게 알리고 싶은 내용 -->
- 주간 학습 통계 조회 시, 날짜 파라미터 설정하여 바로 이전 주뿐만 아니라 모든 이전 날짜 주간 통계 조회 가능합니다.
- 총 공부 시간, 평균 공부 시간 모두 (분) 단위로 내려가니 프론트에서 필요한 형식으로 변형해서 사용하면 될 듯 합니다!

@coderabbitai 한글 답변 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added weekly study statistics for the current user: total minutes, daily average, most/least focused days, and top attendance days. Available via GET /v1/routines/stat/me with an optional date to select the week.

- **Documentation**
  - Enhanced API docs for the weekly statistics endpoint with detailed parameter and response descriptions.

- **Chores**
  - Scheduled batch now auto-aggregates and persists weekly study statistics; improved batch logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MOYEO-74]: https://jelliclesu.atlassian.net/browse/MOYEO-74?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ